### PR TITLE
Allow generating commatrix from csv and fix samples

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/openshift-kni/commatrix/commatrix"
+	"github.com/openshift-kni/commatrix/types"
 )
 
 var (
@@ -82,11 +82,11 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("Error while writing ss matrix to file :%v", err))
 	}
-	// generate the diff matrix between the enpointslice and the ss matrix
-	diff := commatrix.GenerateMatrixDiff(*mat, *ssMat)
+	// generate the diff matrix between the ss and the enpointslice matrix
+	diffCommatrix := commatrix.GenerateMatrixDiff(*mat, *ssMat)
 
-	// write the diff matrix between the enpointslice and the ss matrix to file
-	err = os.WriteFile(filepath.Join(destDir, "matrix-diff-ss"), []byte(diff), 0644)
+	// write the diff matrix between the ss and the enpointslice matrix to a csv file
+	err = commatrix.WriteMatrixToFileByType(diffCommatrix, "matrix-diff-ss", types.FormatCSV, deployment, destDir)
 	if err != nil {
 		panic(fmt.Sprintf("Error writing the diff matrix :%v", err))
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,12 +85,12 @@ func main() {
 	// generate the diff matrix between the enpointslice and the ss matrix
 	diff, err := commatrix.GenerateMatrixDiff(*mat, *ssMat)
 	if err != nil {
-		panic(fmt.Sprintf("Error while writing matrix diff file :%v", err))
+		panic(fmt.Sprintf("Error while generating matrix diff :%v", err))
 	}
 
 	// write the diff matrix between the enpointslice and the ss matrix to file
 	err = os.WriteFile(filepath.Join(destDir, "matrix-diff-ss"), []byte(diff), 0644)
 	if err != nil {
-		panic(fmt.Sprintf("Error writing the diff matrix :%v", err))
+		panic(fmt.Sprintf("Error writing the diff matrix file :%v", err))
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,6 +91,6 @@ func main() {
 	// write the diff matrix between the enpointslice and the ss matrix to file
 	err = os.WriteFile(filepath.Join(destDir, "matrix-diff-ss"), []byte(diff), 0644)
 	if err != nil {
-		panic(fmt.Sprintf("Error writing the diff matrix file :%v", err))
+		panic(fmt.Sprintf("Error writing the diff matrix file: %v", err))
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,13 +82,13 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("Error while writing ss matrix to file :%v", err))
 	}
-	// generate the diff matrix between the ss and the enpointslice matrix
+	// generate the diff matrix between the enpointslice and the ss matrix
 	diff, err := commatrix.GenerateMatrixDiff(*mat, *ssMat)
 	if err != nil {
 		panic(fmt.Sprintf("Error while writing matrix diff file :%v", err))
 	}
 
-	// write the diff matrix between the ss and the enpointslice matrix to a csv file
+	// write the diff matrix between the enpointslice and the ss matrix to file
 	err = os.WriteFile(filepath.Join(destDir, "matrix-diff-ss"), []byte(diff), 0644)
 	if err != nil {
 		panic(fmt.Sprintf("Error writing the diff matrix :%v", err))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/openshift-kni/commatrix/commatrix"
-	"github.com/openshift-kni/commatrix/types"
 )
 
 var (
@@ -83,10 +83,13 @@ func main() {
 		panic(fmt.Sprintf("Error while writing ss matrix to file :%v", err))
 	}
 	// generate the diff matrix between the ss and the enpointslice matrix
-	diffCommatrix := commatrix.GenerateMatrixDiff(*mat, *ssMat)
+	diff, err := commatrix.GenerateMatrixDiff(*mat, *ssMat)
+	if err != nil {
+		panic(fmt.Sprintf("Error while writing matrix diff file :%v", err))
+	}
 
 	// write the diff matrix between the ss and the enpointslice matrix to a csv file
-	err = commatrix.WriteMatrixToFileByType(diffCommatrix, "matrix-diff-ss", types.FormatCSV, deployment, destDir)
+	err = os.WriteFile(filepath.Join(destDir, "matrix-diff-ss"), []byte(diff), 0644)
 	if err != nil {
 		panic(fmt.Sprintf("Error writing the diff matrix :%v", err))
 	}

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -209,7 +209,7 @@ func getComMatrixHeadersByFormat(format string) (string, error) {
 		field := typ.Field(i)
 		tag := field.Tag.Get(format)
 		if tag == "" {
-			return "", fmt.Errorf("field %v has not tag of format %s", field, format)
+			return "", fmt.Errorf("field %v has no tag of format %s", field, format)
 		}
 		tagsList = append(tagsList, tag)
 	}

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -164,15 +164,19 @@ func writeMatrixToFile(matrix types.ComMatrix, fileName, format string, printFn 
 	return os.WriteFile(comMatrixFileName, res, 0644)
 }
 
-func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) string {
-	diff := consts.CSVHeaders + "\n"
+// GenerateMatrixDiff generates a new matrix demonstrating the diff between mat2 to mat1
+func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) types.ComMatrix {
+	diffMatrix := []types.ComDetails{}
 	for _, cd := range mat1.Matrix {
 		if mat2.Contains(cd) {
-			diff += fmt.Sprintf("%s\n", cd)
+			diffMatrix = append(diffMatrix, cd)
 			continue
 		}
 
-		diff += fmt.Sprintf("+ %s\n", cd)
+		// add "+" before cd's mat1 contains but mat2 doesn't
+		newCd := cd
+		newCd.Direction = fmt.Sprintf("+ %s", newCd.Direction)
+		diffMatrix = append(diffMatrix, newCd)
 	}
 
 	for _, cd := range mat2.Matrix {
@@ -183,11 +187,14 @@ func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) string {
 		}
 
 		if !mat1.Contains(cd) {
-			diff += fmt.Sprintf("- %s\n", cd)
+			// add "-" before cd's mat1 doesn't contain but mat2 does
+			missingCd := cd
+			missingCd.Direction = fmt.Sprintf("- %s", missingCd.Direction)
+			diffMatrix = append(diffMatrix, missingCd)
 		}
 	}
 
-	return diff
+	return types.ComMatrix{Matrix: diffMatrix}
 }
 
 func separateMatrixByRole(matrix types.ComMatrix) (types.ComMatrix, types.ComMatrix) {

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -164,7 +164,7 @@ func writeMatrixToFile(matrix types.ComMatrix, fileName, format string, printFn 
 	return os.WriteFile(comMatrixFileName, res, 0644)
 }
 
-// GenerateMatrixDiff generates a new matrix demonstrating the diff between mat2 to mat1
+// GenerateMatrixDiff generates a new matrix demonstrating the diff between mat2 to mat1.
 func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) types.ComMatrix {
 	diffMatrix := []types.ComDetails{}
 	for _, cd := range mat1.Matrix {

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -167,7 +167,7 @@ func writeMatrixToFile(matrix types.ComMatrix, fileName, format string, printFn 
 }
 
 // GenerateMatrixDiff generates the diff between mat1 to mat2.
-func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) (string, error) {
+func GenerateMatrixDiff(mat1, mat2 types.ComMatrix) (string, error) {
 	colNames, err := getComMatrixHeadersByFormat(types.FormatCSV)
 	if err != nil {
 		return "", fmt.Errorf("error getting commatrix CSV tags: %v", err)

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -206,12 +206,12 @@ func getComMatrixColTagsByFormat(format string) string {
 
 	var tagsList []string
 	for i := 0; i < typ.NumField(); i++ {
-        field := typ.Field(i)
-        tag := field.Tag.Get(format)
-        if tag != "" {
-            tagsList = append(tagsList, tag)
-        }
-    }
+		field := typ.Field(i)
+		tag := field.Tag.Get(format)
+		if tag != "" {
+			tagsList = append(tagsList, tag)
+		}
+	}
 
 	return strings.Join(tagsList, ",")
 }

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -166,7 +166,7 @@ func writeMatrixToFile(matrix types.ComMatrix, fileName, format string, printFn 
 	return os.WriteFile(comMatrixFileName, res, 0644)
 }
 
-// GenerateMatrixDiff generates a new matrix demonstrating the diff between mat2 to mat1.
+// GenerateMatrixDiff generates a new matrix demonstrating the diff between mat1 to mat2.
 func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) (string, error) {
 	colNames := getComMatrixColTagsByFormat(types.FormatCSV)
 	if colNames == "" {

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -168,9 +168,9 @@ func writeMatrixToFile(matrix types.ComMatrix, fileName, format string, printFn 
 
 // GenerateMatrixDiff generates the diff between mat1 to mat2.
 func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) (string, error) {
-	colNames := getComMatrixHeadersByFormat(types.FormatCSV)
-	if colNames == "" {
-		return "", fmt.Errorf("error getting commatrix CSV tags")
+	colNames, err := getComMatrixHeadersByFormat(types.FormatCSV)
+	if err != nil {
+		return "", fmt.Errorf("error getting commatrix CSV tags: %v", err)
 	}
 
 	diff := colNames + "\n"
@@ -201,19 +201,20 @@ func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) (string, err
 	return diff, nil
 }
 
-func getComMatrixHeadersByFormat(format string) string {
+func getComMatrixHeadersByFormat(format string) (string, error) {
 	typ := reflect.TypeOf(types.ComDetails{})
 
 	var tagsList []string
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		tag := field.Tag.Get(format)
-		if tag != "" {
-			tagsList = append(tagsList, tag)
+		if tag == "" {
+			return "", fmt.Errorf("field %v has not tag of format %s", field, format)
 		}
+		tagsList = append(tagsList, tag)
 	}
 
-	return strings.Join(tagsList, ",")
+	return strings.Join(tagsList, ","), nil
 }
 
 func separateMatrixByRole(matrix types.ComMatrix) (types.ComMatrix, types.ComMatrix) {

--- a/commatrix/generate.go
+++ b/commatrix/generate.go
@@ -166,9 +166,9 @@ func writeMatrixToFile(matrix types.ComMatrix, fileName, format string, printFn 
 	return os.WriteFile(comMatrixFileName, res, 0644)
 }
 
-// GenerateMatrixDiff generates a new matrix demonstrating the diff between mat1 to mat2.
+// GenerateMatrixDiff generates the diff between mat1 to mat2.
 func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) (string, error) {
-	colNames := getComMatrixColTagsByFormat(types.FormatCSV)
+	colNames := getComMatrixHeadersByFormat(types.FormatCSV)
 	if colNames == "" {
 		return "", fmt.Errorf("error getting commatrix CSV tags")
 	}
@@ -201,7 +201,7 @@ func GenerateMatrixDiff(mat1 types.ComMatrix, mat2 types.ComMatrix) (string, err
 	return diff, nil
 }
 
-func getComMatrixColTagsByFormat(format string) string {
+func getComMatrixHeadersByFormat(format string) string {
 	typ := reflect.TypeOf(types.ComDetails{})
 
 	var tagsList []string

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -8,5 +8,4 @@ const (
 	RoleLabel             = "node-role.kubernetes.io/"
 	DefaultDebugNamespace = "openshift-commatrix-debug"
 	DefaultDebugPodImage  = "quay.io/openshift-release-dev/ocp-release:4.15.12-multi"
-	CSVHeaders            = "Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional"
 )

--- a/samples/custom-entries/example-custom-entries.csv
+++ b/samples/custom-entries/example-custom-entries.csv
@@ -1,3 +1,3 @@
-Direction,Protocol,Port,Namespace,Service,Pod,Container,NodeRole,Optional
+Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 ingress,TCP,9050,example-namespace,example-service,example-pod,example-container,master,false
 ingress,UDP,9051,example-namespace2,example-service2,example-pod2,example-container2,woker,false

--- a/samples/custom-entries/example-custom-entries.json
+++ b/samples/custom-entries/example-custom-entries.json
@@ -2,7 +2,7 @@
     {
         "direction": "ingress",
         "protocol": "TCP",
-        "port": "9050",
+        "port": 9050,
         "namespace": "example-namespace",
         "service": "example-service",
         "pod": "example-pod",
@@ -13,7 +13,7 @@
     {
         "direction": "ingress",
         "protocol": "UDP",
-        "port": "9051",
+        "port": 9051,
         "namespace": "example-namespace2",
         "service": "example-service2",
         "pod": "example-pod2",

--- a/samples/custom-entries/example-custom-entries.yaml
+++ b/samples/custom-entries/example-custom-entries.yaml
@@ -4,7 +4,7 @@
   nodeRole: master
   optional: false
   pod: example-pod
-  port: "9050"
+  port: 9050
   protocol: TCP
   service: example-service
 - container: example-container2
@@ -13,6 +13,6 @@
   nodeRole: worker
   optional: false
   pod: example-pod2
-  port: "9051"
+  port: 9051
   protocol: UDP
   service: example-service2

--- a/types/types.go
+++ b/types/types.go
@@ -34,15 +34,15 @@ type ComMatrix struct {
 }
 
 type ComDetails struct {
-	Direction string `json:"direction" yaml:"direction"`
-	Protocol  string `json:"protocol" yaml:"protocol"`
-	Port      int    `json:"port" yaml:"port"`
-	Namespace string `json:"namespace" yaml:"namespace"`
-	Service   string `json:"service" yaml:"service"`
-	Pod       string `json:"pod" yaml:"pod"`
-	Container string `json:"container" yaml:"container"`
-	NodeRole  string `json:"nodeRole" yaml:"nodeRole"`
-	Optional  bool   `json:"optional" yaml:"optional"`
+	Direction string `json:"direction" yaml:"direction" csv:"Direction"`
+	Protocol  string `json:"protocol" yaml:"protocol" csv:"Protocol"`
+	Port      int    `json:"port" yaml:"port" csv:"Port"`
+	Namespace string `json:"namespace" yaml:"namespace" csv:"Namespace"`
+	Service   string `json:"service" yaml:"service" csv:"Service"`
+	Pod       string `json:"pod" yaml:"pod" csv:"Pod"`
+	Container string `json:"container" yaml:"container" csv:"Container"`
+	NodeRole  string `json:"nodeRole" yaml:"nodeRole" csv:"Node Role"`
+	Optional  bool   `json:"optional" yaml:"optional" csv:"Optional"`
 }
 
 func ToCSV(m ComMatrix) ([]byte, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/openshift-kni/commatrix/consts"
+	"github.com/gocarina/gocsv"
 	"sigs.k8s.io/yaml"
 )
 
@@ -50,18 +50,11 @@ func ToCSV(m ComMatrix) ([]byte, error) {
 	w := bytes.NewBuffer(out)
 	csvwriter := csv.NewWriter(w)
 
-	err := csvwriter.Write(strings.Split(consts.CSVHeaders, ","))
+	err := gocsv.MarshalCSV(&m.Matrix, csvwriter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to write to CSV: %w", err)
+		return nil, err
 	}
 
-	for _, cd := range m.Matrix {
-		record := strings.Split(cd.String(), ",")
-		err := csvwriter.Write(record)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert to CSV foramt: %w", err)
-		}
-	}
 	csvwriter.Flush()
 
 	return w.Bytes(), nil


### PR DESCRIPTION
The node role header of a commatrix in the csv format, defers from those of types json and yaml (`Node Role` instead of `nodeRole`). So, csv annotations in `ComDetails` struct were added.

The previous custom entries examples had some incorrect parameters which were fixed:

1. example-custom-entries.csv: `NodeRole` column was changed to `Node Rule` (as in the documented commatrix.
2. example-custom-entries.yaml and example-custom-entries.json: port was changed from a string to an int (9050 instead of "9050" for example).

a unit test applying the custom entries samples will be added in a separate PR.
