### PR TITLE
Convert bare metal static entries vars to public

### DIFF
--- a/commatrix/commatrix.go
+++ b/commatrix/commatrix.go
@@ -120,11 +120,11 @@ func getStaticEntries(e Env, d Deployment) ([]types.ComDetails, error) {
 
 	switch e {
 	case Baremetal:
-		comDetails = append(comDetails, baremetalStaticEntriesMaster...)
+		comDetails = append(comDetails, BaremetalStaticEntriesMaster...)
 		if d == SNO {
 			break
 		}
-		comDetails = append(comDetails, baremetalStaticEntriesWorker...)
+		comDetails = append(comDetails, BaremetalStaticEntriesWorker...)
 	case Cloud:
 		comDetails = append(comDetails, cloudStaticEntriesMaster...)
 		if d == SNO {

--- a/commatrix/static-custom-entries.go
+++ b/commatrix/static-custom-entries.go
@@ -300,7 +300,7 @@ var generalStaticEntriesMaster = []types.ComDetails{
 	},
 }
 
-var baremetalStaticEntriesWorker = []types.ComDetails{
+var BaremetalStaticEntriesWorker = []types.ComDetails{
 	{
 		Direction: "Ingress",
 		Protocol:  "TCP",
@@ -334,7 +334,7 @@ var baremetalStaticEntriesWorker = []types.ComDetails{
 	},
 }
 
-var baremetalStaticEntriesMaster = []types.ComDetails{
+var BaremetalStaticEntriesMaster = []types.ComDetails{
 	{
 		Direction: "Ingress",
 		Protocol:  "TCP",


### PR DESCRIPTION
Converting bare metal static entries vars to public to enable the use of them in origin tests.