### PR TITLE
Fix GetNodeRole func to return a single node role per node

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -354,15 +354,24 @@ func getComMatrixHeadersByFormat(format string) (string, error) {
 	return strings.Join(tagsList, ","), nil
 }
 
-func GetNodeRoles(node *corev1.Node) []string {
-	roles := []string{}
+func GetNodeRole(node *corev1.Node) (string, error) {
 	if _, ok := node.Labels[consts.RoleLabel+"master"]; ok {
-		roles = append(roles, "master")
+		return "master", nil
+	}
+
+	if _, ok := node.Labels[consts.RoleLabel+"control-plane"]; ok {
+		return "master", nil
 	}
 
 	if _, ok := node.Labels[consts.RoleLabel+"worker"]; ok {
-		roles = append(roles, "worker")
+		return "worker", nil
 	}
 
-	return roles
+	for label := range node.Labels {
+		if strings.HasPrefix(label, consts.RoleLabel) {
+			return strings.TrimPrefix(label, consts.RoleLabel), nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to determine role for node %s", node.Name)
 }


### PR DESCRIPTION
We should return a single node role per node to avoid duplicating the matrix with the same ports on different node roles while listening on the same node (for example, in SNO, which has multiple roles on a single node).