### PR TITLE
Sort matrix diff entries order

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,8 +103,8 @@ func main() {
 		panic(fmt.Sprintf("Error while writing ss matrix to file :%v", err))
 	}
 
-	// generate the diff matrix between the enpointslice and the ss matrix
-	diff, err := matrix.GenerateMatrixDiff(ssMat)
+	// generate the diff between the enpointslice and the ss matrix
+	diff, err := matrix.GenerateDiff(ssMat)
 	if err != nil {
 		panic(fmt.Sprintf("Error while generating matrix diff :%v", err))
 	}

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -73,7 +73,7 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 	}
 
 	commMatrix := &types.ComMatrix{Matrix: epSliceComDetails}
-	log.Debug("Sorting ComMatrix and remove duplicates")
+	log.Debug("Sorting ComMatrix and removing duplicates")
 	commMatrix.SortAndRemoveDuplicates()
 	return commMatrix, nil
 }

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -64,7 +64,7 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 	}
 
 	commMatrix := &types.ComMatrix{Matrix: epSliceComDetails}
-	commMatrix.CleanComDetails()
+	commMatrix.SortAndRemoveDuplicates()
 	return commMatrix, nil
 }
 

--- a/pkg/listening-sockets/listening-sockets.go
+++ b/pkg/listening-sockets/listening-sockets.go
@@ -109,7 +109,7 @@ func (cc *ConnectionCheck) GenerateSS() (*types.ComMatrix, []byte, []byte, error
 	}
 
 	ssComMat := types.ComMatrix{Matrix: nodesComDetails}
-	ssComMat.CleanComDetails()
+	ssComMat.SortAndRemoveDuplicates()
 
 	return &ssComMat, ssOutTCP, ssOutUDP, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -172,7 +172,7 @@ func (m *ComMatrix) generateUnitedMatrix(other *ComMatrix) *ComMatrix {
 // cd which m contains but other doesn't --> 1
 // cd both m and other contains --> 0
 // cd which other doesn't contain but m does --> -1.
-func (m *ComMatrix) mapDiffBetweenMatrices(other *ComMatrix) map[string]int {
+func (m *ComMatrix) markDiffBetweenMatrices(other *ComMatrix) map[string]int {
 	mapComDetailToSign := make(map[string]int)
 
 	for _, cd := range m.Matrix {
@@ -204,7 +204,7 @@ func (m *ComMatrix) mapDiffBetweenMatrices(other *ComMatrix) map[string]int {
 func (m *ComMatrix) GenerateMatrixDiff(other *ComMatrix) (string, error) {
 	unitedComMatrix := m.generateUnitedMatrix(other)
 	unitedComMatrix.CleanComDetails()
-	mapComDetailToSign := m.mapDiffBetweenMatrices(other)
+	mapComDetailToSign := m.markDiffBetweenMatrices(other)
 
 	colNames, err := getComMatrixHeadersByFormat(FormatCSV)
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -329,7 +329,7 @@ func (m *ComMatrix) ToNFTables() ([]byte, error) {
 	return []byte(result), nil
 }
 
-// CleanComDetails deletes duplicates in matrix and sort it.
+// SortAndRemoveDuplicates removes duplicates in the matrix and sort it.
 func (m *ComMatrix) SortAndRemoveDuplicates() {
 	allKeys := make(map[string]bool)
 	res := []ComDetails{}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -371,7 +371,7 @@ func (m *ComMatrix) sort() {
 	})
 }
 
-// CleanComDetails deletes duplicates in matrix and sort it
+// CleanComDetails deletes duplicates in matrix and sort it.
 func (m *ComMatrix) CleanComDetails() {
 	m.deleteDuplicates()
 	m.sort()


### PR DESCRIPTION
This PR modifies ComMatrix method `GenerateMatrixDiff` to generate an organized diff using the `CleanComDetails` method sorting logic.

The updated `GenerateMatrixDiff` method works as follows:
1. Calling `generateUnitedMatrix` method to unite two matrices (without duplications).
2. Sorting the United matrix using `CleanComDetails` method.
3. Calling `mapDiffBetweenMatrices` method mark the diff between the matrices using a map.
4. Iterating over the **sorted** United matrix and generate the diff:  a `+` or  `-` sign (or a nothing) will be added to the each cd according to the marking done in previous (3) step.

