### PR TITLE
Change MNO deployment type to Standard type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FORMAT ?= csv
 CLUSTER_ENV ?= baremetal
 DEST_DIR ?= .
-DEPLOYMENT ?= mno
+DEPLOYMENT ?= standard
 DEBUG ?=
 GO_SRC := cmd/main.go
 EXECUTABLE := commatrix-gen

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&destDir, "destDir", "communication-matrix", "Output files dir")
 	flag.StringVar(&format, "format", "csv", "Desired format (json,yaml,csv,nft)")
 	flag.StringVar(&envStr, "env", "baremetal", "Cluster environment (baremetal/cloud)")
-	flag.StringVar(&deploymentStr, "deployment", "mno", "Deployment type (mno/sno)")
+	flag.StringVar(&deploymentStr, "deployment", "standard", "Deployment type (standard/sno)")
 	flag.StringVar(&customEntriesPath, "customEntriesPath", "", "Add custom entries from a file to the matrix")
 	flag.StringVar(&customEntriesFormat, "customEntriesFormat", "", "Set the format of the custom entries file (json,yaml,csv)")
 	flag.BoolVar(&debug, "debug", false, "Debug logs")

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -154,7 +154,7 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 		return comDetails, nil
 	}
 
-	comDetails = append(comDetails, types.MNOStaticEntries...)
+	comDetails = append(comDetails, types.StandardStaticEntries...)
 	comDetails = append(comDetails, types.GeneralStaticEntriesWorker...)
 	log.Debug("Successfully determined static entries")
 	return comDetails, nil

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -484,7 +484,7 @@ var CloudStaticEntriesMaster = []ComDetails{
 	},
 }
 
-var MNOStaticEntries = []ComDetails{
+var StandardStaticEntries = []ComDetails{
 	{
 		Direction: "Ingress",
 		Protocol:  "UDP",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -31,7 +31,7 @@ type Deployment int
 
 const (
 	SNO Deployment = iota
-	MNO
+	Standard
 )
 
 const (
@@ -80,8 +80,8 @@ func GetEnv(envStr string) (Env, error) {
 
 func GetDeployment(deploymentStr string) (Deployment, error) {
 	switch deploymentStr {
-	case "mno":
-		return MNO, nil
+	case "standard":
+		return Standard, nil
 	case "sno":
 		return SNO, nil
 	default:
@@ -138,7 +138,7 @@ func (m *ComMatrix) WriteMatrixToFileByType(utilsHelpers utils.UtilsInterface, f
 		if err != nil {
 			return err
 		}
-		if deployment == MNO {
+		if deployment == Standard {
 			err := workerMatrix.writeMatrixToFile(utilsHelpers, fileNamePrefix+"-worker", format, destDir)
 			if err != nil {
 				return err


### PR DESCRIPTION
Addressing [this](https://github.com/openshift/origin/pull/28946#discussion_r1720396672) comment in the origin repo. As `MNO` is not a standard name for "Not SNO", we changed the type name to be `Standard`.