### PR TITLE
Remove Diff method from ComMatrix struct

### DIFF
--- a/pkg/matrix-diff/matrix-diff.go
+++ b/pkg/matrix-diff/matrix-diff.go
@@ -100,17 +100,3 @@ func (m *MatrixDiff) GenerateUniqueSecondary() *types.ComMatrix {
 
 	return &matrix
 }
-
-// Returns true if the diff between the matrices is empty, meaning matrices are equal.
-func (m *MatrixDiff) IsEmpty() bool {
-	uniquePrimarey := m.GenerateUniquePrimary()
-	uniqueSecondary := m.GenerateUniqueSecondary()
-
-	// Check if the unique diff matrices are not empty
-	if len(uniquePrimarey.Matrix) > 0 || len(uniqueSecondary.Matrix) > 0 {
-		return false
-	}
-
-	// Unique diff matrices are empty, ComMatrices are equal
-	return true
-}

--- a/pkg/matrix-diff/matrix-diff.go
+++ b/pkg/matrix-diff/matrix-diff.go
@@ -17,7 +17,9 @@ const (
 	uniqueSecondary
 )
 
+// MatrixDiff represent the diff between two comMatrices.
 type MatrixDiff struct {
+	// Matrix Diff's ComMatrix is the combined matrix of the primary and secondary matrices.
 	types.ComMatrix
 	cdToStatus map[string]status
 }
@@ -97,4 +99,18 @@ func (m *MatrixDiff) GenerateUniqueSecondary() *types.ComMatrix {
 	}
 
 	return &matrix
+}
+
+// Returns true if the diff between the matrices is empty, meaning matrices are equal.
+func (m *MatrixDiff) IsEmpty() bool {
+	uniquePrimarey := m.GenerateUniquePrimary()
+	uniqueSecondary := m.GenerateUniqueSecondary()
+
+	// Check if the unique diff matrices are not empty
+	if len(uniquePrimarey.Matrix) > 0 || len(uniqueSecondary.Matrix) > 0 {
+		return false
+	}
+
+	// Unique diff matrices are empty, ComMatrices are equal
+	return true
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -192,25 +192,6 @@ func (m *ComMatrix) writeMatrixToFile(utilsHelpers utils.UtilsInterface, fileNam
 	return utilsHelpers.WriteFile(comMatrixFileName, res)
 }
 
-// Diff returns the diff ComMatrix.
-func (m *ComMatrix) Diff(other ComMatrix) ComMatrix {
-	diff := []ComDetails{}
-	for _, cd1 := range m.Matrix {
-		found := false
-		for _, cd2 := range other.Matrix {
-			if cd1.Equals(cd2) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			diff = append(diff, cd1)
-		}
-	}
-
-	return ComMatrix{Matrix: diff}
-}
-
 func (m *ComMatrix) Contains(cd ComDetails) bool {
 	for _, cd1 := range m.Matrix {
 		if cd1.Equals(cd) {


### PR DESCRIPTION
This PR removes the `Diff` Method of the `ComMatrix` struct was removed, since it is not necessary when having the `MatrixDiff` struct which represents the diff between two comMatrices.

Also, comments were added to the `MatrixDiff` struct to make it's components and purpose clearer.