### PR TITLE
Fix service record info

### DIFF
--- a/pkg/endpointslices/endpointslices.go
+++ b/pkg/endpointslices/endpointslices.go
@@ -190,7 +190,7 @@ func (ei *EndpointSlicesInfo) toComDetails(nodesRoles map[string]string) ([]type
 				Pod:       name,
 				Container: containerName,
 				NodeRole:  role,
-				Service:   ei.Service.Namespace,
+				Service:   ei.Service.Name,
 				Optional:  optional,
 			})
 		}


### PR DESCRIPTION
The service name should be printed to the matrix, not its namespace.