### PR TITLE
Add a test to validate the Communication Matrix matches 'ss'

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift-kni/commatrix/pkg/client"
 	commatrixcreator "github.com/openshift-kni/commatrix/pkg/commatrix-creator"
+	"github.com/openshift-kni/commatrix/pkg/consts"
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	listeningsockets "github.com/openshift-kni/commatrix/pkg/listening-sockets"
 	matrixdiff "github.com/openshift-kni/commatrix/pkg/matrix-diff"
@@ -102,8 +103,14 @@ func main() {
 		log.Panicf("Failed creating listening socket check: %v", err)
 	}
 
+	log.Debug("Creating namespace")
+	err = utilsHelpers.CreateNamespace(consts.DefaultDebugNamespace)
+	if err != nil {
+		log.Panicf("Failed to create namespace: %v", err)
+	}
+
 	log.Debug("Generating SS matrix and raw files")
-	ssMat, ssOutTCP, ssOutUDP, err := listeningCheck.GenerateSS()
+	ssMat, ssOutTCP, ssOutUDP, err := listeningCheck.GenerateSS(consts.DefaultDebugNamespace)
 	if err != nil {
 		log.Panicf("Error while generating the listening check matrix and ss raws: %v", err)
 	}

--- a/pkg/listening-sockets/listening_sockets_test.go
+++ b/pkg/listening-sockets/listening_sockets_test.go
@@ -157,16 +157,6 @@ var _ = Describe("GenerateSS", func() {
 			AnyTimes()
 
 		mockUtils.EXPECT().
-			CreateNamespace(consts.DefaultDebugNamespace).
-			Return(nil).
-			AnyTimes()
-
-		mockUtils.EXPECT().
-			DeleteNamespace(consts.DefaultDebugNamespace).
-			Return(nil).
-			AnyTimes()
-
-		mockUtils.EXPECT().
 			CreatePodOnNode(gomock.Any(), consts.DefaultDebugNamespace, consts.DefaultDebugPodImage).
 			Return(mockPod, nil).AnyTimes()
 
@@ -175,7 +165,7 @@ var _ = Describe("GenerateSS", func() {
 		connectionCheck, err := NewCheck(clientset, mockUtils, "/some/dest/dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		ssMat, ssOutTCP, ssOutUDP, err := connectionCheck.GenerateSS()
+		ssMat, ssOutTCP, ssOutUDP, err := connectionCheck.GenerateSS(consts.DefaultDebugNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(normalizeOutput(string(ssOutTCP))).To(Equal(normalizeOutput(expectedTCPOutput)))

--- a/test/pkg/firewall/firewall.go
+++ b/test/pkg/firewall/firewall.go
@@ -14,8 +14,8 @@ import (
 )
 
 // Apply the firewall rules on the node.
-func ApplyRulesToNode(NFTtable []byte, nodeName, artifactsDir string, utilsHelpers utils.UtilsInterface) error {
-	debugPod, err := utilsHelpers.CreatePodOnNode(nodeName, consts.DefaultDebugNamespace, consts.DefaultDebugPodImage)
+func ApplyRulesToNode(NFTtable []byte, nodeName, namespace, artifactsDir string, utilsHelpers utils.UtilsInterface) error {
+	debugPod, err := utilsHelpers.CreatePodOnNode(nodeName, namespace, consts.DefaultDebugPodImage)
 	if err != nil {
 		return fmt.Errorf("failed to create debug pod on node %s: %w", nodeName, err)
 	}

--- a/test/pkg/node/node.go
+++ b/test/pkg/node/node.go
@@ -21,8 +21,8 @@ const (
 )
 
 // SoftRebootNodeAndWaitForDisconnect soft reboots given node and wait for node to be unreachable.
-func SoftRebootNodeAndWaitForDisconnect(utilsHelpers utils.UtilsInterface, cs *client.ClientSet, nodeName string) error {
-	debugPod, err := utilsHelpers.CreatePodOnNode(nodeName, consts.DefaultDebugNamespace, consts.DefaultDebugPodImage)
+func SoftRebootNodeAndWaitForDisconnect(utilsHelpers utils.UtilsInterface, cs *client.ClientSet, nodeName, namespace string) error {
+	debugPod, err := utilsHelpers.CreatePodOnNode(nodeName, namespace, consts.DefaultDebugPodImage)
 	if err != nil {
 		return fmt.Errorf("failed to create debug pod on node %s: %w", nodeName, err)
 	}


### PR DESCRIPTION
This test validates the ports in a generated communication matrix match a snapshot of the node's listening ports (created with the Linux `ss` utility)