### PR TITLE
E2E validation test: skip dns ports used during provisioning

### DIFF
--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -270,6 +270,12 @@ func filterSSMatrix(mat *types.ComMatrix) (*types.ComMatrix, error) {
 			continue
 		}
 
+		// Skip dns ports used during provisioning for dhcp and tftp,
+		// not used for external traffic
+		if cd.Service == "dnsmasq" || cd.Service == "dig" {
+			continue
+		}
+
 		res = append(res, cd)
 	}
 


### PR DESCRIPTION
Skip dns ports used during provisioning for dhcp and tftp, not used for external traffic, the test shouldn't validate these ports.