### PR TITLE
Allow adding extra endpoint slices for open ports in e2e test

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -202,6 +202,23 @@ func (m *ComMatrix) Contains(cd ComDetails) bool {
 	return false
 }
 
+func (m *ComMatrix) ToNFTablesRules() string {
+	var tcpPorts []string
+	var udpPorts []string
+	for _, line := range m.Matrix {
+		if line.Protocol == "TCP" {
+			tcpPorts = append(tcpPorts, fmt.Sprint(line.Port))
+		} else if line.Protocol == "UDP" {
+			udpPorts = append(udpPorts, fmt.Sprint(line.Port))
+		}
+	}
+
+	tcpPortsStr := strings.Join(tcpPorts, ", ")
+	udpPortsStr := strings.Join(udpPorts, ", ")
+
+	return fmt.Sprintf("tcp dport { %s } accept\nudp dport { %s } accept", tcpPortsStr, udpPortsStr)
+}
+
 func (m *ComMatrix) ToNFTables() ([]byte, error) {
 	var tcpPorts []string
 	var udpPorts []string

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,16 +17,16 @@ import (
 )
 
 var (
-	cs                      *client.ClientSet
-	commatrix               *types.ComMatrix
-	isSNO                   bool
-	isBM                    bool
-	deployment              types.Deployment
-	infra                   types.Env
-	utilsHelpers            utils.UtilsInterface
-	epExporter              *endpointslices.EndpointSlicesExporter
-	nodeList                *corev1.NodeList
-	artifactsDir            string
+	cs           *client.ClientSet
+	commatrix    *types.ComMatrix
+	isSNO        bool
+	isBM         bool
+	deployment   types.Deployment
+	infra        types.Env
+	utilsHelpers utils.UtilsInterface
+	epExporter   *endpointslices.EndpointSlicesExporter
+	nodeList     *corev1.NodeList
+	artifactsDir string
 )
 
 const testNS = "openshift-commatrix-test"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/commatrix/pkg/client"
-	commatrixcreator "github.com/openshift-kni/commatrix/pkg/commatrix-creator"
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
 	"github.com/openshift-kni/commatrix/pkg/utils"
@@ -28,8 +27,6 @@ var (
 	epExporter              *endpointslices.EndpointSlicesExporter
 	nodeList                *corev1.NodeList
 	artifactsDir            string
-	extraNFTablesMasterFile = ""
-	extraNFTablesWorkerFile = ""
 )
 
 const testNS = "openshift-commatrix-test"
@@ -75,13 +72,6 @@ var _ = BeforeSuite(func() {
 	epExporter, err = endpointslices.New(cs)
 	Expect(err).ToNot(HaveOccurred())
 
-	By("Generating comMatrix")
-	commMatrixCreator, err := commatrixcreator.New(epExporter, "", "", infra, deployment)
-	Expect(err).NotTo(HaveOccurred())
-
-	commatrix, err = commMatrixCreator.CreateEndpointMatrix()
-	Expect(err).NotTo(HaveOccurred())
-
 	By("Creating test namespace")
 	err = utilsHelpers.CreateNamespace(testNS)
 	Expect(err).ToNot(HaveOccurred())
@@ -89,17 +79,6 @@ var _ = BeforeSuite(func() {
 	nodeList = &corev1.NodeList{}
 	err = cs.List(context.TODO(), nodeList)
 	Expect(err).ToNot(HaveOccurred())
-
-	// get the EXTRA_NFTABLES_FILE if it not exist value is ""
-	val, exists := os.LookupEnv("EXTRA_NFTABLES_MASTER_FILE")
-	if exists {
-		extraNFTablesMasterFile = val
-	}
-
-	val, exists = os.LookupEnv("EXTRA_NFTABLES_WORKER_FILE")
-	if exists {
-		extraNFTablesWorkerFile = val
-	}
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -139,15 +139,6 @@ var _ = Describe("Nftables", func() {
 	})
 })
 
-func appendNftableRulesFromFile(nftablesRules string, extraNFTablesFile string) (string, error) {
-	extraNFTablesValue, err := os.ReadFile(extraNFTablesFile)
-	if err != nil {
-		return "", fmt.Errorf("failed to read extra nftables from file: %v", err)
-	}
-
-	return nftablesRules + "\n" + string(extraNFTablesValue), nil
-}
-
 func createNftableFromRules(rules string) string {
 	return fmt.Sprintf(`#!/usr/sbin/nft -f
       table inet openshift_filter {

--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Nftables", func() {
 		}
 
 		// waiting for mcp start updating
-		// cluster.WaitForMCPUpdateToStart(cs)
+		cluster.WaitForMCPUpdateToStart(cs)
 
 		// waiting for MCP to finish updating
 		cluster.WaitForMCPReadyState(cs)

--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -79,9 +79,6 @@ var _ = Describe("Nftables", func() {
 		for role, nftablesConfig := range nodeRoleToNFTables {
 			By(fmt.Sprintf("Applying firewall on %s nodes", role))
 
-			err = os.WriteFile(filepath.Join(artifactsDir, "config"), nftablesConfig, 0644)
-			Expect(err).ToNot(HaveOccurred())
-
 			machineConfig, err := firewall.CreateMachineConfig(cs, nftablesConfig, artifactsDir,
 				role, utilsHelpers)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -28,9 +28,9 @@ var _ = Describe("Nftables", func() {
 	It("should apply firewall by blocking all ports except the ones OCP is listening on", func() {
 		masterMat, workerMat := commatrix.SeparateMatrixByRole()
 
-		var podsToIgnoreMasterMat, podsToIgnoreWorkerMat types.ComMatrix
+		var portsToIgnoreMasterMat, portsToIgnoreWorkerMat types.ComMatrix
 		if portsToIgnoreCommatrix != nil {
-			podsToIgnoreMasterMat, podsToIgnoreWorkerMat = portsToIgnoreCommatrix.SeparateMatrixByRole()
+			portsToIgnoreMasterMat, portsToIgnoreWorkerMat = portsToIgnoreCommatrix.SeparateMatrixByRole()
 		}
 
 		nodeRoleToNFTables := make(map[string][]byte)
@@ -46,23 +46,21 @@ var _ = Describe("Nftables", func() {
 			if _, exists := nodeRoleToNFTables[role]; !exists {
 				if role == workerNodeRole {
 					roleMat = workerMat
-					podsToIgnoreMat = podsToIgnoreWorkerMat
+					podsToIgnoreMat = portsToIgnoreWorkerMat
 					extraNftablesFileEnv = "EXTRA_NFTABLES_WORKER_FILE"
 				} else {
 					roleMat = masterMat
-					podsToIgnoreMat = podsToIgnoreMasterMat
+					podsToIgnoreMat = portsToIgnoreMasterMat
 					extraNftablesFileEnv = "EXTRA_NFTABLES_MASTER_FILE"
 				}
 
 				nftablesRules := roleMat.ToNFTablesRules()
-				Expect(err).NotTo(HaveOccurred())
 
 				extraNFTablesFile, _ := os.LookupEnv(extraNftablesFileEnv)
 				if extraNFTablesFile != "" {
 					extraNFTablesValue, err := os.ReadFile(extraNFTablesFile)
 					Expect(err).NotTo(HaveOccurred())
 					nftablesRules += "\n\t\t\t\t\t" + string(extraNFTablesValue)
-					Expect(err).NotTo(HaveOccurred())
 				}
 
 				if podsToIgnoreMat.Matrix != nil {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -178,9 +178,15 @@ var _ = Describe("Validation", func() {
 			logrus.Warningf("the following ports are not used: \n %s", notUsedEPSMat)
 		}
 
-		// generate the diff matrix between the open ports to ignore matrix and the missing endpoint slice matrix (based on the diff between the enpointslice and the ss matrix)
-		diffIgonre := matrixdiff.Generate(diff.GenerateUniqueSecondary(), portsToIgnoreCommatrix)
-		missingEPSMat := diffIgonre.GenerateUniquePrimary()
+		var missingEPSMat *types.ComMatrix
+		if portsToIgnoreCommatrix != nil && portsToIgnoreCommatrix.Matrix != nil {
+			// generate the diff matrix between the open ports to ignore matrix and the missing endpoint slice matrix (based on the diff between the enpointslice and the ss matrix)
+			diffIgonre := matrixdiff.Generate(diff.GenerateUniqueSecondary(), portsToIgnoreCommatrix)
+			missingEPSMat = diffIgonre.GenerateUniquePrimary()
+		} else {
+			missingEPSMat = diff.GenerateUniqueSecondary()
+		}
+
 		if len(missingEPSMat.Matrix) > 0 {
 			err := fmt.Errorf("the following ports are used but don't have an endpointslice: \n %s", missingEPSMat)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -27,11 +27,6 @@ import (
 )
 
 var (
-	extraEndpointSlicesFilePath   = ""
-	extraEndpointSlicesFileFormat = ""
-)
-
-var (
 	// Entries which are open on the worker node instead of master in standard cluster.
 	// Will be excluded in diff generatation between documented and generated comMatrix.
 	StandardExcludedMasterComDetails = []types.ComDetails{


### PR DESCRIPTION
This PR allow specifying an extra `comdetails` file, that contains open ports which does not have endpoint.
Those ports will be ignored when comparing the differences between the open ports matrix with the endpoint slices communication matrix, to avoid unnecessary failures. 
Also, those ports will be added to the nftable rules in the e2e nftables test.
This option is needed for certain ports only.

The extra ports should be stored in a file (csv\json\yaml), and its path and format should be passed as the following env vars when running the e2e-test make target:
`OPEN_PORTS_TO_IGNORE_FILE`, `OPEN_PORTS_TO_IGNORE_FORMAT`

Additionally, this PR moves the extra nftables env vars extraction to the test's file.