### PR TITLE
update the wait for mc to wait just if it a new mc or its a real update on the mc

### DIFF
--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -69,19 +69,23 @@ var _ = Describe("Nftables", func() {
 				role, utilsHelpers)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = cluster.ApplyMachineConfig(machineConfig, cs)
+			updated, err := cluster.ApplyMachineConfig(machineConfig, cs)
 			Expect(err).ToNot(HaveOccurred())
 
+			if updated {
+				// wait to MCP to start the update.
+				cluster.WaitForMCPUpdateToStart(cs, role)
+
+				// Wait for MCP update to be ready.
+				cluster.WaitForMCPReadyState(cs, role)
+
+				log.Println("MCP update completed successfully.")
+			} else {
+				log.Println("No update needed. MCP update skipped.")
+			}
 		}
 
-		// waiting for mcp start updating
-		cluster.WaitForMCPUpdateToStart(cs)
-
-		// waiting for MCP to finish updating
-		cluster.WaitForMCPReadyState(cs)
-
 		nodeName := nodeList.Items[0].Name
-
 		By("Rebooting first node: " + nodeName + "and waiting for disconnect \n")
 		err = node.SoftRebootNodeAndWaitForDisconnect(utilsHelpers, cs, nodeName, testNS)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
update the wait for mc to wait just if it a new mc or its a real update on the mc
for now if there is an update that is not a real update( like run with same configuration), the code will stuck to wait for the mcp to start update and this is not a good behavior 