### PR TITLE
update the wait for mc to wait just if it a new mc or its a real update on the mc

### DIFF
--- a/pkg/listening-sockets/listening-sockets.go
+++ b/pkg/listening-sockets/listening-sockets.go
@@ -263,7 +263,7 @@ func filterEntries(ssEntries []string) []string {
 func parseComDetail(ssEntry string) *types.ComDetails {
 	serviceName, err := extractServiceName(ssEntry)
 	if err != nil {
-		log.Debugf(err.Error())
+		log.Debug(err.Error())
 	}
 
 	fields := strings.Fields(ssEntry)
@@ -272,7 +272,7 @@ func parseComDetail(ssEntry string) *types.ComDetails {
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		log.Debugf(err.Error())
+		log.Debug(err.Error())
 		return nil
 	}
 

--- a/test/pkg/cluster/cluster.go
+++ b/test/pkg/cluster/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	mcoac "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sTypes "k8s.io/apimachinery/pkg/types"
 	controllersClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -38,48 +38,21 @@ func GetClusterVersion(cs *client.ClientSet) (string, error) {
 	return strings.Join(clusterVersionParts[:2], "."), nil
 }
 
-func WaitForMCPUpdateToStart(cs *client.ClientSet) {
+func WaitForMCPUpdateToStart(cs *client.ClientSet, role string) {
 	gomega.Eventually(func() (bool, error) {
-		mcpList := &machineconfigurationv1.MachineConfigPoolList{}
-		err := cs.List(context.TODO(), mcpList, &controllersClient.ListOptions{})
+		mcp := &machineconfigurationv1.MachineConfigPool{}
+		err := cs.Get(context.TODO(), controllersClient.ObjectKey{Name: role}, mcp)
 		if err != nil {
 			return false, fmt.Errorf("failed to list MachineConfigPools: %v", err)
 		}
 
-		for _, mcp := range mcpList.Items {
-			if mcp.Status.UpdatedMachineCount != mcp.Status.MachineCount {
-				log.Printf("MCP %s has started updating", mcp.Name)
-				return true, nil // At least one MCP has started updating
-			}
+		if mcp.Status.UpdatedMachineCount != mcp.Status.MachineCount {
+			log.Printf("MCP %s has started updating", mcp.Name)
+			return true, nil
 		}
 
 		return false, nil
 	}, timeout, 30*time.Second).Should(gomega.BeTrue(), "Timed out waiting for MCP to start updating")
-}
-
-func WaitForMCPReadyState(c *client.ClientSet) {
-	gomega.Eventually(func() (bool, error) {
-		mcpList := &machineconfigurationv1.MachineConfigPoolList{}
-		err := c.List(context.TODO(), mcpList, &controllersClient.ListOptions{})
-		if err != nil {
-			return false, fmt.Errorf("failed to list MachineConfigPools: %v", err)
-		}
-
-		mcpsReady := true
-		for _, mcp := range mcpList.Items {
-			if mcp.Status.ReadyMachineCount != mcp.Status.MachineCount {
-				mcpsReady = false
-				log.Printf("MCP %s is still updating or degraded\n", mcp.Name)
-				break
-			}
-		}
-
-		if mcpsReady {
-			log.Println("All MCPs are ready and updated")
-		}
-
-		return mcpsReady, nil
-	}, timeout, 30*time.Second).Should(gomega.BeTrue(), "Timed out waiting for MCPs to reach the desired state")
 }
 
 func AddNFTSvcToNodeDisruptionPolicy(cs *client.ClientSet) error {
@@ -109,34 +82,59 @@ func AddNFTSvcToNodeDisruptionPolicy(cs *client.ClientSet) error {
 	return nil
 }
 
-func ApplyMachineConfig(yamlInput []byte, c *client.ClientSet) error {
+func ApplyMachineConfigAndCheckChange(yamlInput []byte, c *client.ClientSet) (bool, error) {
 	obj := &machineconfigurationv1.MachineConfig{}
 	if err := yaml.Unmarshal(yamlInput, obj); err != nil {
-		return fmt.Errorf("failed to unmarshal YAML: %w", err)
+		return false, fmt.Errorf("failed to unmarshal YAML: %w", err)
 	}
 
 	err := c.Create(context.TODO(), obj)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create MachineConfig: %w", err)
+			return false, fmt.Errorf("failed to create MachineConfig: %w", err)
 		}
 
-		// If it already exists, retrieve the current version to update
+		// If it already exists, retrieve the current version to update.
 		existingMC := &machineconfigurationv1.MachineConfig{}
-		if err = c.Get(context.TODO(), k8sTypes.NamespacedName{Name: obj.Name}, existingMC); err != nil {
-			return fmt.Errorf("failed to get existing MachineConfig: %w", err)
+		if err = c.Get(context.TODO(), controllersClient.ObjectKey{Name: obj.Name}, existingMC); err != nil {
+			return false, fmt.Errorf("failed to get existing MachineConfig: %w", err)
 		}
 
-		obj.ResourceVersion = existingMC.ResourceVersion
-		if updateErr := c.Update(context.TODO(), obj); updateErr != nil {
-			return fmt.Errorf("failed to update MachineConfig: %w", updateErr)
+		// Compare if there is a real change
+		if !reflect.DeepEqual(existingMC.Spec, obj.Spec) {
+			obj.ResourceVersion = existingMC.ResourceVersion
+			if err := c.Update(context.TODO(), obj); err != nil {
+				return false, fmt.Errorf("failed to update MachineConfig: %w", err)
+			}
+
+			log.Println("MachineConfig updated successfully.")
+			return true, nil
 		}
-		log.Println("MachineConfig updated successfully.")
-	} else {
-		log.Println("MachineConfig created successfully.")
+
+		log.Println("No changes detected in MachineConfig. Skipping update.")
+		return false, nil
 	}
 
-	return nil
+	log.Println("MachineConfig created successfully.")
+	return true, nil
+}
+
+func WaitForMCPReadyState(c *client.ClientSet, role string) {
+	gomega.Eventually(func() (bool, error) {
+		mcp := &machineconfigurationv1.MachineConfigPool{}
+		err := c.Get(context.TODO(), controllersClient.ObjectKey{Name: role}, mcp)
+		if err != nil {
+			return false, fmt.Errorf("failed to list MachineConfigPools: %v", err)
+		}
+
+		if mcp.Status.ReadyMachineCount != mcp.Status.MachineCount {
+			log.Printf("MCP %s is still updating or degraded\n", mcp.Name)
+			return false, nil
+		}
+
+		log.Println("All MCPs are ready and updated")
+		return true, nil
+	}, timeout, 30*time.Second).Should(gomega.BeTrue(), "Timed out waiting for MCPs to reach the desired state")
 }
 
 func ValidateClusterVersionAndMachineConfiguration(cs *client.ClientSet) error {


### PR DESCRIPTION
update the wait for mc to wait just if it a new mc or its a real update on the mc
for now if there is an update that is not a real update( like run with same configuration), the code will stuck to wait for the mcp to start update and this is not a good behavior