### PR TITLE
Handle WaitForNodeNotReady for SNO use

### DIFF
--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Nftables", func() {
 
 		nodeName := nodeList.Items[0].Name
 		By("Rebooting first node: " + nodeName + "and waiting for disconnect \n")
-		err = node.SoftRebootNodeAndWaitForDisconnect(utilsHelpers, cs, nodeName, testNS)
+		err = node.SoftRebootNodeAndWaitForDisconnect(utilsHelpers, cs, nodeName, testNS, isSNO)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for node to be ready")


### PR DESCRIPTION
When we try to get a node in an SNO cluster that is in "NotReady" state, we will get a "connection refused" error.
Because of that, when trying to confirm that a node is in a "NotReady" state in an SNO cluster, instead of checking nodes condition we would like to check if the error returned from when trying to get the node is indeed "connection refused". If so, we can assume that the node is in "NotReady" state.