### PR TITLE
Add port 6388 to bm documented commatrix

### DIFF
--- a/docs/stable/raw/bm.csv
+++ b/docs/stable/raw/bm.csv
@@ -9,6 +9,7 @@ Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecur
 Ingress,TCP,6180,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6183,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6385,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
+Ingress,TCP,6388,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE

--- a/docs/stable/unique/bm.csv
+++ b/docs/stable/unique/bm.csv
@@ -4,6 +4,7 @@ Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
 Ingress,TCP,6180,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6183,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6385,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
+Ingress,TCP,6388,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9447,openshift-machine-api,,metal3-baremetal-operator,,master,FALSE


### PR DESCRIPTION
This PR adds port 6388 to the bm documented commatrix based on the failures of [nightly-4.18-telco5g-network-flow-matrix-bm](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-telco5g-network-flow-matrix-bm/1888000033740034048) and [nightly-4.19-telco5g-network-flow-matrix-bm](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-telco5g-network-flow-matrix-bm/1888000045475696640) runs.
This change should be updated in both release-4.19 and release-4.18 branches.