### PR TITLE
Handle missing eps for open ports used only internally

### DIFF
--- a/docs/ignore-ports/ports-to-ignore-in-host-port-matrix.csv
+++ b/docs/ignore-ports/ports-to-ignore-in-host-port-matrix.csv
@@ -1,0 +1,5 @@
+Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
+Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
+Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
+Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
+Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,worker,FALSE

--- a/docs/stable/raw/aws-sno.csv
+++ b/docs/stable/raw/aws-sno.csv
@@ -10,7 +10,6 @@ Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserve
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
-Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
 Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
 Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE
@@ -30,8 +29,6 @@ Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/raw/aws.csv
+++ b/docs/stable/raw/aws.csv
@@ -8,7 +8,6 @@ Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserve
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
-Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
 Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
 Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE
@@ -28,8 +27,6 @@ Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
@@ -50,7 +47,5 @@ Ingress,TCP,9537,Host system service,crio-metrics,,,worker,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,worker,FALSE
 Ingress,TCP,10250,Host system service,kubelet,,,worker,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,worker,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,worker,FALSE
 Ingress,UDP,111,Host system service,rpcbind,,,worker,TRUE
 Ingress,UDP,6081,openshift-ovn-kubernetes,ovn-kubernetes geneve,,,worker,FALSE

--- a/docs/stable/raw/bm-sno.csv
+++ b/docs/stable/raw/bm-sno.csv
@@ -11,7 +11,6 @@ Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserve
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
-Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
 Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
 Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE
@@ -31,8 +30,6 @@ Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/raw/bm.csv
+++ b/docs/stable/raw/bm.csv
@@ -14,7 +14,6 @@ Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserve
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
-Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
 Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
 Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE

--- a/docs/stable/unique/aws-sno.csv
+++ b/docs/stable/unique/aws-sno.csv
@@ -3,5 +3,3 @@ Ingress,TCP,80,openshift-ingress,router-default,router-default,router,master,FAL
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE

--- a/docs/stable/unique/aws.csv
+++ b/docs/stable/unique/aws.csv
@@ -1,9 +1,5 @@
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,80,openshift-ingress,router-default,router-default,router,worker,FALSE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,worker,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,worker,FALSE

--- a/docs/stable/unique/bm-sno.csv
+++ b/docs/stable/unique/bm-sno.csv
@@ -4,5 +4,3 @@ Ingress,TCP,443,openshift-ingress,router-internal-default,router-default,router,
 Ingress,TCP,1936,openshift-ingress,router-internal-default,router-default,router,master,FALSE
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE

--- a/docs/stable/unique/common-master.csv
+++ b/docs/stable/unique/common-master.csv
@@ -8,7 +8,6 @@ Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserve
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
-Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
 Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
 Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE

--- a/pkg/endpointslices/endpointslices.go
+++ b/pkg/endpointslices/endpointslices.go
@@ -94,7 +94,7 @@ func (ep *EndpointSlicesExporter) LoadEndpointSlicesInfo() error {
 			continue
 		}
 
-		if !filterServiceTypes(service) && !filterHostNetwork(pods.Items[0]) {
+		if !FilterServiceTypes(service) && !FilterHostNetwork(pods.Items[0]) {
 			continue
 		}
 

--- a/pkg/endpointslices/filter.go
+++ b/pkg/endpointslices/filter.go
@@ -5,13 +5,13 @@ import (
 )
 
 // filterHostNetwork checks if the pods behind the endpointSlice are host network.
-func filterHostNetwork(pod corev1.Pod) bool {
+func FilterHostNetwork(pod corev1.Pod) bool {
 	// Assuming all pods in an EndpointSlice are uniformly on host network or not, we only check the first one.
 	return pod.Spec.HostNetwork
 }
 
 // FilterServiceTypes checks if the service behind the endpointSlice is of type LoadBalancer or NodePort.
-func filterServiceTypes(service corev1.Service) bool {
+func FilterServiceTypes(service corev1.Service) bool {
 	if service.Spec.Type != corev1.ServiceTypeLoadBalancer &&
 		service.Spec.Type != corev1.ServiceTypeNodePort {
 		return false

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -188,16 +188,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      9099,
-		NodeRole:  "master",
-		Service:   "cluster-version-operator",
-		Namespace: "openshift-cluster-version",
-		Pod:       "cluster-version-operator",
-		Container: "cluster-version-operator",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      9980,
 		NodeRole:  "master",
 		Service:   "etcd",
@@ -416,29 +406,7 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	},
 }
 
-var CloudStaticEntriesWorker = []ComDetails{
-	{
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10300,
-		NodeRole:  "worker",
-		Service:   "csi-livenessprobe",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-driver",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10309,
-		NodeRole:  "worker",
-		Service:   "csi-node-driver",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-node-driver-registrar",
-		Optional:  false,
-	},
-}
+var CloudStaticEntriesWorker = []ComDetails{}
 
 var CloudStaticEntriesMaster = []ComDetails{
 	{
@@ -460,26 +428,6 @@ var CloudStaticEntriesMaster = []ComDetails{
 		Namespace: "openshift-cloud-controller-manager-operator",
 		Pod:       "cloud-controller-manager",
 		Container: "cloud-controller-manager",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10300,
-		NodeRole:  "master",
-		Service:   "csi-livenessprobe",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-driver",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10309,
-		NodeRole:  "master",
-		Service:   "csi-node-driver",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-node-driver-registrar",
 		Optional:  false,
 	},
 }


### PR DESCRIPTION
added a file for ports to ignore in the ss diff with the eps
use the filter of the service that are internal and have the host network true +
remove the ports that are internal and hostnetwork true from the const file
