### PR TITLE
[release-4.18] Remove ports 5050 and 9447 from docs

### DIFF
--- a/docs/stable/raw/bm.csv
+++ b/docs/stable/raw/bm.csv
@@ -4,7 +4,6 @@ Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
 Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
-Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
 Ingress,TCP,6180,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6183,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
@@ -25,7 +24,6 @@ Ingress,TCP,9192,openshift-cluster-machine-approver,machine-approver,machine-app
 Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cluster-cloud-controller-manager,cluster-cloud-controller-manager,master,FALSE
 Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
-Ingress,TCP,9447,openshift-machine-api,,metal3-baremetal-operator,,master,FALSE
 Ingress,TCP,9537,Host system service,crio-metrics,,,master,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
 Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE

--- a/docs/stable/unique/bm.csv
+++ b/docs/stable/unique/bm.csv
@@ -1,13 +1,11 @@
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
-Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
 Ingress,TCP,6180,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6183,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6385,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6388,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
-Ingress,TCP,9447,openshift-machine-api,,metal3-baremetal-operator,,master,FALSE
 Ingress,TCP,18080,openshift-kni-infra,,coredns,coredns,master,FALSE
 Ingress,UDP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
 Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,worker,FALSE

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -326,16 +326,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      5050,
-		NodeRole:  "master",
-		Service:   "",
-		Namespace: "openshift-machine-api",
-		Pod:       "ironic-proxy",
-		Container: "ironic-proxy",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      9444,
 		NodeRole:  "master",
 		Service:   "",
@@ -372,16 +362,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 		Namespace: "openshift-kni-infra",
 		Pod:       "coredns",
 		Container: "coredns",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      9447,
-		NodeRole:  "master",
-		Service:   "",
-		Namespace: "openshift-machine-api",
-		Pod:       "metal3-baremetal-operator",
-		Container: "",
 		Optional:  false,
 	},
 }


### PR DESCRIPTION
As there were some merge conflicts, [PR#110](https://github.com/openshift-kni/commatrix/pull/110) was cherry-picked locally.