### PR TITLE
[release-4.17] Remove port 5050 from static entries

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -326,16 +326,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      5050,
-		NodeRole:  "master",
-		Service:   "",
-		Namespace: "openshift-machine-api",
-		Pod:       "ironic-proxy",
-		Container: "ironic-proxy",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      9444,
 		NodeRole:  "master",
 		Service:   "",


### PR DESCRIPTION
Port 5050 has been removed from 4.17 documented commatrix (see [PR](https://github.com/openshift/openshift-docs/pull/90465)) as it is no open on that version. Hence, it can now be removed from static entries of 4.17.