### PR TITLE
Filter hostPort ports for inclusion in generated endpointslice commatrix

### DIFF
--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -41,7 +41,7 @@ func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath stri
 // port number, namespace, service name, pod, container, node role, and flow optionality for OpenShift.
 func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, error) {
 	log.Debug("Loading EndpointSlices information")
-	err := cm.exporter.LoadEndpointSlicesInfo()
+	err := cm.exporter.LoadExposedEndpointSlicesInfo()
 	if err != nil {
 		log.Errorf("Failed loading endpointslices: %v", err)
 		return nil, fmt.Errorf("failed loading endpointslices: %w", err)

--- a/pkg/endpointslices/filter.go
+++ b/pkg/endpointslices/filter.go
@@ -2,16 +2,54 @@ package endpointslices
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
+// Holds a mapping between a container port and it's corresponding endpointslice Port.
+type EndpointPortInfo struct {
+	EndpointPort  discoveryv1.EndpointPort
+	ContainerPort corev1.ContainerPort
+}
+
+// getEndpointSlicePortsFromPod returns the corresponding slice of EndpointPortInfo for the given pod.
+func getEndpointSlicePortsFromPod(pod corev1.Pod, endpointPorts []discoveryv1.EndpointPort) []EndpointPortInfo {
+	ports := []EndpointPortInfo{}
+	for _, endpointPort := range endpointPorts {
+		if endpointPort.Port == nil {
+			continue
+		}
+
+		for _, container := range pod.Spec.Containers {
+			for _, containerPort := range container.Ports {
+				if containerPort.ContainerPort == *endpointPort.Port {
+					ports = append(ports, EndpointPortInfo{EndpointPort: endpointPort, ContainerPort: containerPort})
+				}
+			}
+		}
+	}
+	return ports
+}
+
+// filterHostNetwork checks if the pods behind the endpointSlice are using host ports.
+func filterEndpointPortsByPodHostPort(portsInfo []EndpointPortInfo) []discoveryv1.EndpointPort {
+	// Assuming all pods in an EndpointSlice are uniformly on host ports or not, we only check the first one.
+	filteredPorts := []discoveryv1.EndpointPort{}
+	for _, port := range portsInfo {
+		if port.ContainerPort.HostPort != 0 {
+			filteredPorts = append(filteredPorts, port.EndpointPort)
+		}
+	}
+	return filteredPorts
+}
+
 // filterHostNetwork checks if the pods behind the endpointSlice are host network.
-func filterHostNetwork(pod corev1.Pod) bool {
+func isHostNetworked(pod corev1.Pod) bool {
 	// Assuming all pods in an EndpointSlice are uniformly on host network or not, we only check the first one.
 	return pod.Spec.HostNetwork
 }
 
 // FilterServiceTypes checks if the service behind the endpointSlice is of type LoadBalancer or NodePort.
-func filterServiceTypes(service corev1.Service) bool {
+func isExposedService(service corev1.Service) bool {
 	if service.Spec.Type != corev1.ServiceTypeLoadBalancer &&
 		service.Spec.Type != corev1.ServiceTypeNodePort {
 		return false


### PR DESCRIPTION
As it is now, when creating the endpointslices communication matrix, we filter the ports which are are not associate with a NodePort or a LoadBalancer service and that are not specified as `hostNetwork: true` in the pod's sped - The purpose is to append to the communication matrix, only ports that are exposed externally.

Another way to check if a port is exposed externally, is to check whether is has a hostPort - meaning the container’s port is directly bind to a specific port on the node.

This PR adds a filter that checks whether a container port is associated with a hostPort - if so it will be added to the communication matrix as it means it is an exposed port.