### PR TITLE
add a new required  flag for the platfrom type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 FORMAT ?= csv
+PLATFORM_TYPE ?= aws
 DEST_DIR ?= .
-DEBUG ?=
+DEBUG ?= false
 SUITE ?= all
 GO_SRC := cmd/main.go
 EXECUTABLE := oc-commatrix
@@ -66,8 +67,10 @@ clean-cross-build:
 generate: build
 	rm -rf $(DEST_DIR)/communication-matrix
 	mkdir -p $(DEST_DIR)/communication-matrix
-	./$(EXECUTABLE) generate --format=$(FORMAT) --destDir=$(DEST_DIR)/communication-matrix --customEntriesPath=$(CUSTOM_ENTRIES_PATH) --customEntriesFormat=$(CUSTOM_ENTRIES_FORMAT) --host-open-ports $(if $(DEBUG),--debug=true)
+	./$(EXECUTABLE) generate --format=$(FORMAT)  --destDir=$(DEST_DIR)/communication-matrix --customEntriesPath=$(CUSTOM_ENTRIES_PATH) \
+	--customEntriesFormat=$(CUSTOM_ENTRIES_FORMAT) --host-open-ports --platform-type=$(PLATFORM_TYPE) $(if $(filter true,$(DEBUG)),--debug)
 
+  
 .PHONY: install
 install:
 	install $(EXECUTABLE) $(INSTALL_DIR)

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -43,6 +43,7 @@ Usage:
   oc commatrix generate [flags]
 
 Flags:
+      --platform-type string         Platform Type (baremetal, aws), Required
       --customEntriesFormat string   Set the format of the custom entries file (json,yaml,csv)
       --customEntriesPath string     Add custom entries from a file to the matrix
       --debug                        Debug logs (default is false)
@@ -58,10 +59,11 @@ Once you run the `oc commatrix generate` command, the plugin will
 generate a communication matrix based on the ingress flows in your
 OpenShift cluster. The output will be saved to a file (destDir) in the chosen format,
 similar to the following:
+> **Note:** The `--platform-type` flag is required for all commands.
 
-`csv example`
+`csv example on aws`
 ```sh
-$ oc commatrix generate --format csv
+$ oc commatrix generate --format csv --platform-type aws
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,22,Host system service,sshd,,,master,true
 Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,false
@@ -69,9 +71,9 @@ Ingress,TCP,80,openshift-ingress,router-internal-default,router-default,router,m
 Ingress,TCP,111,Host system service,rpcbind,,,master,true
 ```
 
-`json example`
+`json example on baremetal`
 ```sh
-$ oc commatrix generate --format json
+$ oc commatrix generate --format json --platform-type baremetal
 [
     {
         "direction": "Ingress",
@@ -98,9 +100,9 @@ $ oc commatrix generate --format json
 ]
 ```
 
-`host-open-ports example command`
+`host-open-ports example command on aws`
 ```sh
-$ oc commatrix generate --host-open-ports --format csv
+$ oc commatrix generate --platform-type aws --host-open-ports --format csv
 ```
 
 the command will generate the follwing paths:
@@ -151,9 +153,9 @@ UNCONN 0      0      127.0.0.1:323   0.0.0.0:* users:(("chronyd",pid=2805,fd=5))
 UNCONN 0      0      127.0.0.1:708   0.0.0.0:* users:(("rpc.statd",pid=3922,fd=8))
 ```
 
-`customEntriesFormat and customEntriesPath example command`
+`customEntriesFormat and customEntriesPath example command on baremetal`
 ```sh
-$ oc commatrix generate --format csv --customEntriesFormat csv --customEntriesPath "communication-matrix/customEntriesPath"
+$ oc commatrix generate --platform-type baremetal --format csv --customEntriesFormat csv --customEntriesPath "communication-matrix/customEntriesPath"
 ```
 
 `contents of communication-matrix/customEntriesPath`

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -159,21 +159,33 @@ func Validate(o *GenerateOptions) error {
 			o.format, strings.Join(validFormats, ", "))
 	}
 
-	if o.customEntriesPath == "" {
-		return nil
-	}
-
-	if o.customEntriesFormat == "" {
-		return fmt.Errorf("you must specify the --customEntriesFormat when using --customEntriesPath")
-	}
-
-	if !slices.Contains(validCustomEntriesFormats, o.customEntriesFormat) {
-		return fmt.Errorf("invalid custom entries format '%s', valid options are: %s",
-			o.customEntriesFormat, strings.Join(validCustomEntriesFormats, ", "))
+	if err := validateCustomEntries(o.customEntriesPath, o.customEntriesFormat, validCustomEntriesFormats); err != nil {
+		return err
 	}
 
 	if !slices.Contains(validPlatformType, Platform(o.platformType)) {
 		return fmt.Errorf("invalid platform type %s, valid options: %v", o.platformType, validPlatformType)
+	}
+
+	return nil
+}
+
+func validateCustomEntries(path, format string, validFormats []string) error {
+	if path == "" && format == "" { // dont need to validate
+		return nil
+	}
+
+	if path != "" && format == "" { // if one of them are missing
+		return fmt.Errorf("you must specify the --customEntriesFormat when using --customEntriesPath")
+	}
+
+	if path == "" && format != "" { // if one of them are missing
+		return fmt.Errorf("you must specify the --customEntriesPath when using --customEntriesFormat")
+	}
+
+	if !slices.Contains(validFormats, format) { // poth are set with wrong format
+		return fmt.Errorf("invalid custom entries format '%s', valid options are: %s",
+			format, strings.Join(validFormats, ", "))
 	}
 
 	return nil

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -33,22 +33,31 @@ var (
 
 	`)
 	CommatrixExample = templates.Examples(`
-			 # Generate the communication matrix in default format (csv):
-			 oc commatrix generate  
+			 # Note: The --platform-type flag is required for all commands.
+
+			 # Generate the communication matrix in default format (csv) on AWS:
+			 oc commatrix generate --platform-type aws 
 			 
-			 # Generate the communication matrix in nft format:
-			 oc commatrix generate --format nft 
+			 # Generate the communication matrix in nft format on baremetal platform:
+			 oc commatrix generate --platform-type baremetal --format nft 
+
+			 # Generate the communication matrix in json format with debug logs on AWS:
+			 oc commatrix generate --platform-type aws --format json --debug
 			 
-			 # Generate the communication matrix in json format with debug logs:
-			 oc commatrix generate --format json --debug
+			 # Generate communication matrix, host open ports matrix, and their difference in yaml format on baremetal:
+			 oc commatrix generate --platform-type baremetal --host-open-ports --format yaml 
 			 
-			 # Generate communication matrix, host open ports matrix, and their difference in yaml format:
-			 oc commatrix generate --host-open-ports --format yaml 
-			 
-			 # Generate the communication matrix in json format with custom entries:
-			 oc commatrix generate --format json --customEntriesPath /path/to/customEntriesFile --customEntriesFormat json
+			 # Generate the communication matrix in json format with custom entries on AWS:
+			 oc commatrix generate --platform-type aws --format json --customEntriesPath /path/to/customEntriesFile --customEntriesFormat json
 			 
 	`)
+)
+
+type Platform string
+
+const (
+	PlatformBaremetal Platform = "baremetal"
+	PlatformAWS       Platform = "aws"
 )
 
 var (
@@ -64,9 +73,15 @@ var (
 		types.FormatJSON,
 		types.FormatYAML,
 	}
+
+	validPlatformType = []Platform{
+		PlatformBaremetal,
+		PlatformAWS,
+	}
 )
 
 type GenerateOptions struct {
+	platformType        string
 	destDir             string
 	format              string
 	customEntriesPath   string
@@ -123,12 +138,17 @@ func NewCmdCommatrixGenerate(cs *client.ClientSet, streams genericiooptions.IOSt
 			return nil
 		},
 	}
+
 	cmd.Flags().StringVar(&o.destDir, "destDir", "", "Output files dir (default communication-matrix)")
 	cmd.Flags().StringVar(&o.format, "format", "csv", "Desired format (json,yaml,csv,nft)")
-	cmd.Flags().BoolVar(&o.debug, "debug", false, "Debug logs")
+	cmd.Flags().StringVar(&o.platformType, "platform-type", "", fmt.Sprintf("Platform Type %v, Required", validPlatformType))
 	cmd.Flags().StringVar(&o.customEntriesPath, "customEntriesPath", "", "Add custom entries from a file to the matrix")
 	cmd.Flags().StringVar(&o.customEntriesFormat, "customEntriesFormat", "", "Set the format of the custom entries file (json,yaml,csv)")
 	cmd.Flags().BoolVar(&o.openPorts, "host-open-ports", false, "Generate communication matrix, host open ports matrix, and their difference")
+	cmd.Flags().BoolVar(&o.debug, "debug", false, "Debug logs")
+	if err := cmd.MarkFlagRequired("platform-type"); err != nil { // make it as required flag
+		log.Fatalf("failed to mark platform-type as required: %v", err)
+	}
 
 	return cmd
 }
@@ -150,6 +170,10 @@ func Validate(o *GenerateOptions) error {
 	if !slices.Contains(validCustomEntriesFormats, o.customEntriesFormat) {
 		return fmt.Errorf("invalid custom entries format '%s', valid options are: %s",
 			o.customEntriesFormat, strings.Join(validCustomEntriesFormats, ", "))
+	}
+
+	if !slices.Contains(validPlatformType, Platform(o.platformType)) {
+		return fmt.Errorf("invalid platform type %s, valid options: %v", o.platformType, validPlatformType)
 	}
 
 	return nil
@@ -189,12 +213,7 @@ func Run(o *GenerateOptions) (err error) {
 		deployment = types.SNO
 	}
 
-	isBM, err := o.utilsHelpers.IsBMInfra()
-	if err != nil {
-		return fmt.Errorf("failed to check is bm cluster %s", err)
-	}
-
-	if isBM {
+	if Platform(o.platformType) == PlatformBaremetal {
 		infra = types.Baremetal
 	}
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -202,7 +202,7 @@ func Run(o *GenerateOptions) (err error) {
 
 	log.Debug("Detecting deployment and infra types")
 	deployment := types.Standard
-	infra := types.Cloud
+	infra := types.AWS
 
 	isSNO, err := o.utilsHelpers.IsSNOCluster()
 	if err != nil {

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -205,6 +205,14 @@ func TestCommatrixGeneration(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Should return failure when customEntriesFormat is set but customEntriesPath is missing",
+			args: []string{"generate", "--customEntriesFormat", "nft", "--platform-type", "aws"},
+			expectedFunc: func() (string, error) {
+				return "", fmt.Errorf("you must specify the --customEntriesPath when using --customEntriesFormat")
+			},
+			wantErr: true,
+		},
+		{
 			name: "Should return failure when customEntriesFormat not valid",
 			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--customEntriesFormat", "invalid", "--platform-type", "aws"},
 			expectedFunc: func() (string, error) {

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -156,7 +156,7 @@ func TestCommatrixGeneration(t *testing.T) {
 	}{
 		{
 			name: "Should generate CSV output",
-			args: []string{"generate", "--format", "csv", "--destDir", destDir},
+			args: []string{"generate", "--format", "csv", "--destDir", destDir, "--platform-type", "aws"},
 			expectedFunc: func() (string, error) {
 				expectedOutput, err := expectedComMatrix.ToCSV()
 				return string(expectedOutput), err
@@ -165,7 +165,7 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should generate JSON output",
-			args: []string{"generate", "--format", "json", "--destDir", destDir},
+			args: []string{"generate", "--format", "json", "--destDir", destDir, "--platform-type", "aws"},
 			expectedFunc: func() (string, error) {
 				expectedOutput, err := expectedComMatrix.ToJSON()
 				return string(expectedOutput), err
@@ -173,8 +173,24 @@ func TestCommatrixGeneration(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Should Return failure on misssing platform-type",
+			args: []string{"generate"},
+			expectedFunc: func() (string, error) {
+				return "", fmt.Errorf("required flag(s) \"platform-type\" not set")
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should Return failure on platform-type validation",
+			args: []string{"generate", "--platform-type", "test"},
+			expectedFunc: func() (string, error) {
+				return "", fmt.Errorf("invalid platform type test, valid options: [baremetal aws]")
+			},
+			wantErr: true,
+		},
+		{
 			name: "Should Return failure on format validation",
-			args: []string{"generate", "--format", "test"},
+			args: []string{"generate", "--format", "test", "--platform-type", "aws"},
 			expectedFunc: func() (string, error) {
 				return "", fmt.Errorf("invalid format 'test', valid options are: csv, json, yaml, nft")
 			},
@@ -182,7 +198,7 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should return failure when customEntriesPath is set but customEntriesFormat is missing",
-			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile"},
+			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--platform-type", "aws"},
 			expectedFunc: func() (string, error) {
 				return "", fmt.Errorf("you must specify the --customEntriesFormat when using --customEntriesPath")
 			},
@@ -190,9 +206,9 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should return failure when customEntriesFormat not valid",
-			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--customEntriesFormat", "invalid"},
+			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--customEntriesFormat", "invalid", "--platform-type", "aws"},
 			expectedFunc: func() (string, error) {
-				return "", fmt.Errorf("invalid custom entries format")
+				return "", fmt.Errorf("invalid custom entries format 'invalid', valid options are: csv, json, yaml")
 			},
 			wantErr: true,
 		},
@@ -238,6 +254,7 @@ func TestCommatrixGeneration(t *testing.T) {
 				assert.Contains(t, errOut.String(), expectedOutput)
 				require.Error(t, err)
 				require.Error(t, expectedErr)
+				require.Equal(t, expectedErr, err) // errors need to be equal, expectedErr==err
 			} else {
 				require.NoError(t, err)
 				require.NoError(t, expectedErr)

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -136,7 +136,7 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 			break
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
-	case types.Cloud:
+	case types.AWS:
 		log.Debug("Adding Cloud static entries")
 		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
 		if cm.d == types.SNO {

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -231,7 +231,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud standard cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud standard cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.Standard)
+			cm, err := New(nil, "", "", types.AWS, types.Standard)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -246,7 +246,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud SNO cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.SNO)
+			cm, err := New(nil, "", "", types.AWS, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -296,7 +296,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix with custom entries", func() {
 			g.By("Creating new communication matrix with static entries")
-			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, types.Cloud, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, types.AWS, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -320,7 +320,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
 			g.By("Creating new communication matrix without static entries")
-			commatrixCreator, err := New(endpointSlices, "", "", types.Cloud, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "", "", types.AWS, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -24,7 +24,7 @@ type Env int
 
 const (
 	Baremetal Env = iota
-	Cloud
+	AWS
 )
 
 type Deployment int
@@ -71,8 +71,8 @@ func GetEnv(envStr string) (Env, error) {
 	switch envStr {
 	case "baremetal":
 		return Baremetal, nil
-	case "cloud":
-		return Cloud, nil
+	case "aws":
+		return AWS, nil
 	default:
 		return -1, fmt.Errorf("invalid cluster environment: %s", envStr)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func() {
 		deployment = types.SNO
 	}
 
-	infra = types.Cloud
+	infra = types.AWS
 	isBM, err = utilsHelpers.IsBMInfra()
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
add a new required flag 
- added a new string var platform-type  (baremetal,aws). required.
- update the readme with the new flag and examples
- update the makefile to use the new var
- update the validation function to handle errors on the new var
- make it as required failed if not set
- update the unittest of the generate class
- change the infra var from Cloud to AWS
- add a missing compare to errors on the unitest