### PR TITLE
refactor e2e test

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -320,3 +320,24 @@ func GetNodeRole(node *corev1.Node) (string, error) {
 
 	return "", fmt.Errorf("unable to determine role for node %s", node.Name)
 }
+
+func ParseToComDetailsList(content []byte, format string) ([]ComDetails, error) {
+	var comDetails []ComDetails
+	switch format {
+	case FormatJSON:
+		if err := json.Unmarshal(content, &comDetails); err != nil {
+			return nil, err
+		}
+	case FormatYAML:
+		if err := yaml.Unmarshal(content, &comDetails); err != nil {
+			return nil, err
+		}
+	case FormatCSV:
+		if err := gocsv.UnmarshalBytes(content, &comDetails); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid value for format must be (json,yaml,csv)")
+	}
+	return comDetails, nil
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -10,22 +9,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/commatrix/pkg/client"
-	commatrixcreator "github.com/openshift-kni/commatrix/pkg/commatrix-creator"
-	"github.com/openshift-kni/commatrix/pkg/endpointslices"
-	"github.com/openshift-kni/commatrix/pkg/types"
 	"github.com/openshift-kni/commatrix/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
 var (
 	cs           *client.ClientSet
-	commatrix    *types.ComMatrix
 	isSNO        bool
 	isBM         bool
-	deployment   types.Deployment
-	infra        types.Env
 	utilsHelpers utils.UtilsInterface
-	epExporter   *endpointslices.EndpointSlicesExporter
 	nodeList     *corev1.NodeList
 	artifactsDir string
 )
@@ -43,59 +35,21 @@ var _ = BeforeSuite(func() {
 	if artifactsDir == "" {
 		log.Println("env var ARTIFACT_DIR is not set, using default value")
 	}
-	artifactsDir = filepath.Join(artifactsDir, "commatrix-e2e")
 
+	artifactsDir = filepath.Join(artifactsDir, "commatrix-e2e")
 	err := os.MkdirAll(artifactsDir, 0755)
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Creating the clients for the Generating step")
+	By("Creating New Commatrix Client")
 	cs, err = client.New()
 	Expect(err).NotTo(HaveOccurred())
 
 	utilsHelpers = utils.New(cs)
-
-	deployment = types.Standard
 	isSNO, err = utilsHelpers.IsSNOCluster()
 	Expect(err).NotTo(HaveOccurred())
 
-	if isSNO {
-		deployment = types.SNO
-	}
-
-	infra = types.AWS
 	isBM, err = utilsHelpers.IsBMInfra()
 	Expect(err).NotTo(HaveOccurred())
-
-	if isBM {
-		infra = types.Baremetal
-	}
-
-	epExporter, err = endpointslices.New(cs)
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Generating comMatrix")
-	commMatrixCreator, err := commatrixcreator.New(epExporter, "", "", infra, deployment)
-	Expect(err).NotTo(HaveOccurred())
-
-	commatrix, err = commMatrixCreator.CreateEndpointMatrix()
-	Expect(err).NotTo(HaveOccurred())
-
-	err = commatrix.WriteMatrixToFileByType(utilsHelpers, "communication-matrix", types.FormatCSV, deployment, artifactsDir)
-	Expect(err).ToNot(HaveOccurred())
-
-	By("Creating test namespace")
-	err = utilsHelpers.CreateNamespace(testNS)
-	Expect(err).ToNot(HaveOccurred())
-
-	nodeList = &corev1.NodeList{}
-	err = cs.List(context.TODO(), nodeList)
-	Expect(err).ToNot(HaveOccurred())
-})
-
-var _ = AfterSuite(func() {
-	By("Deleting Namespace")
-	err := utilsHelpers.DeleteNamespace(testNS)
-	Expect(err).ToNot(HaveOccurred())
 })
 
 func TestE2e(t *testing.T) {


### PR DESCRIPTION

- use the oc command to generate the matric's and read them, for simulate for user running.
- Create a `ParseToComDetailsList` function to refactor the process of loading `ComDetailsList` from files, removing reliance on the `commMatrixCreator`.
- This refactor improves the e2e test by making it closer to user behavior and centralizing the parsing logic for better reuse and maintainability.
- Replaced internal matrix generation functions with the OpenShift CLI (oc) commands to generate and retrieve matrices, aligning the test process with actual user interactions.