### PR TITLE
export GetStaticEntries for external use and add GetCommonEntries function on diff package

### DIFF
--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -52,7 +52,7 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 	}
 
 	log.Debug("Getting static entries")
-	staticEntries, err := cm.getStaticEntries()
+	staticEntries, err := cm.GetStaticEntries()
 	if err != nil {
 		log.Errorf("Failed adding static entries: %s", err)
 		return nil, fmt.Errorf("failed adding static entries: %s", err)
@@ -102,7 +102,7 @@ func (cm *CommunicationMatrixCreator) GetComDetailsListFromFile() ([]types.ComDe
 	return res, nil
 }
 
-func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, error) {
+func (cm *CommunicationMatrixCreator) GetStaticEntries() ([]types.ComDetails, error) {
 	log.Debug("Determining static entries based on environment and deployment")
 	comDetails := []types.ComDetails{}
 

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -314,8 +314,8 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			diff := matrixdiff.Generate(&wantedComMatrix, commatrix)
 
 			g.By("Checking whether diff is empty")
-			o.Expect(diff.GenerateUniquePrimary().Matrix).To(o.BeEmpty())
-			o.Expect(diff.GenerateUniqueSecondary().Matrix).To(o.BeEmpty())
+			o.Expect(diff.GetUniquePrimary().Matrix).To(o.BeEmpty())
+			o.Expect(diff.GetUniqueSecondary().Matrix).To(o.BeEmpty())
 		})
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
@@ -334,8 +334,8 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			diff := matrixdiff.Generate(&wantedComMatrix, commatrix)
 
 			g.By("Checking whether diff is empty")
-			o.Expect(diff.GenerateUniquePrimary().Matrix).To(o.BeEmpty())
-			o.Expect(diff.GenerateUniqueSecondary().Matrix).To(o.BeEmpty())
+			o.Expect(diff.GetUniquePrimary().Matrix).To(o.BeEmpty())
+			o.Expect(diff.GetUniqueSecondary().Matrix).To(o.BeEmpty())
 		})
 	})
 })

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -206,7 +206,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.getStaticEntries()
+			gotComDetails, err := cm.GetStaticEntries()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to wanted comDetails")
@@ -221,7 +221,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.getStaticEntries()
+			gotComDetails, err := cm.GetStaticEntries()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to wanted comDetails")
@@ -235,7 +235,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.getStaticEntries()
+			gotComDetails, err := cm.GetStaticEntries()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to wanted comDetails")
@@ -250,7 +250,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.getStaticEntries()
+			gotComDetails, err := cm.GetStaticEntries()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to wanted comDetails")
@@ -264,7 +264,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.getStaticEntries()
+			gotComDetails, err := cm.GetStaticEntries()
 			o.Expect(err).To(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to empty comDetails")

--- a/pkg/matrix-diff/matrix-diff.go
+++ b/pkg/matrix-diff/matrix-diff.go
@@ -75,8 +75,8 @@ func (m *MatrixDiff) String() (string, error) {
 	return diff, nil
 }
 
-// Generates the unique entries in primary mat.
-func (m *MatrixDiff) GenerateUniquePrimary() *types.ComMatrix {
+// Get the unique entries in primary mat.
+func (m *MatrixDiff) GetUniquePrimary() *types.ComMatrix {
 	matrix := types.ComMatrix{}
 
 	for _, cd := range m.Matrix {
@@ -88,12 +88,25 @@ func (m *MatrixDiff) GenerateUniquePrimary() *types.ComMatrix {
 	return &matrix
 }
 
-// Generates the unique entries in secondary mat.
-func (m *MatrixDiff) GenerateUniqueSecondary() *types.ComMatrix {
+// Get the unique entries in secondary mat.
+func (m *MatrixDiff) GetUniqueSecondary() *types.ComMatrix {
 	matrix := types.ComMatrix{}
 
 	for _, cd := range m.Matrix {
 		if m.cdToStatus[cd.String()] == uniqueSecondary {
+			matrix.Matrix = append(matrix.Matrix, cd)
+		}
+	}
+
+	return &matrix
+}
+
+// Get the common entries in both mat.
+func (m *MatrixDiff) GetSharedEntries() *types.ComMatrix {
+	matrix := types.ComMatrix{}
+
+	for _, cd := range m.Matrix {
+		if m.cdToStatus[cd.String()] == both {
 			matrix.Matrix = append(matrix.Matrix, cd)
 		}
 	}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Validation", func() {
 
 		By("comparing new and documented commatrices")
 		// Get ports that are in the documented commatrix but not in the generated commatrix.
-		notUsedPortsMat := endpointslicesDiffWithDocMat.GenerateUniqueSecondary()
+		notUsedPortsMat := endpointslicesDiffWithDocMat.GetUniqueSecondary()
 		if len(notUsedPortsMat.Matrix) > 0 {
 			logrus.Warningf("the following ports are documented but are not used:\n%s", notUsedPortsMat)
 		}
@@ -147,7 +147,7 @@ var _ = Describe("Validation", func() {
 
 		// Get ports that are in the generated commatrix but not in the documented commatrix,
 		// and ignore the ports in given file (if exists)
-		missingPortsMat := endpointslicesDiffWithDocMat.GenerateUniquePrimary()
+		missingPortsMat := endpointslicesDiffWithDocMat.GetUniquePrimary()
 		if openPortsToIgnoreFile != "" && openPortsToIgnoreFormat != "" {
 			portsToIgnoreFileContent, err := os.ReadFile(openPortsToIgnoreFile)
 			Expect(err).ToNot(HaveOccurred())
@@ -158,9 +158,9 @@ var _ = Describe("Validation", func() {
 			portsToIgnoreMat = &types.ComMatrix{Matrix: portsToIgnoreComDetails}
 
 			// generate the diff matrix between the open ports to ignore matrix and the missing ports in the documented commatrix (based on the diff between the enpointslice and the doc matrix)
-			nonDocumentedEndpointslicesMat := endpointslicesDiffWithDocMat.GenerateUniquePrimary()
+			nonDocumentedEndpointslicesMat := endpointslicesDiffWithDocMat.GetUniquePrimary()
 			endpointslicesDiffWithIgnoredPorts := matrixdiff.Generate(nonDocumentedEndpointslicesMat, portsToIgnoreMat)
-			missingPortsMat = endpointslicesDiffWithIgnoredPorts.GenerateUniquePrimary()
+			missingPortsMat = endpointslicesDiffWithIgnoredPorts.GetUniquePrimary()
 		}
 
 		if len(missingPortsMat.Matrix) > 0 {


### PR DESCRIPTION
- export GetStaticEntries for external use
  the getStaticEntries function has been exported (made public) by renaming it to GetStaticEntries, allowing it to be used in other package
- create a GetCommonEntries to return the common entries on a matrix
  Create GetCommonEntries to return entries shared by both matrices in a diff
- Renamed GenerateUniquePrimary and GenerateUniqueSecondary to GetUniquePrimary and GetUniqueSecondary for better clarity, since the functions return values rather than generate the