### PR TITLE
handle the noneplatformtype platform (removing the added platform-type var and add the support of none in the code)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 FORMAT ?= csv
-PLATFORM_TYPE ?= aws
 DEST_DIR ?= .
 DEBUG ?= false
 SUITE ?= all
@@ -67,10 +66,8 @@ clean-cross-build:
 generate: build
 	rm -rf $(DEST_DIR)/communication-matrix
 	mkdir -p $(DEST_DIR)/communication-matrix
-	./$(EXECUTABLE) generate --format=$(FORMAT)  --destDir=$(DEST_DIR)/communication-matrix --customEntriesPath=$(CUSTOM_ENTRIES_PATH) \
-	--customEntriesFormat=$(CUSTOM_ENTRIES_FORMAT) --host-open-ports --platform-type=$(PLATFORM_TYPE) $(if $(filter true,$(DEBUG)),--debug)
+	./$(EXECUTABLE) generate --format=$(FORMAT) --destDir=$(DEST_DIR)/communication-matrix --customEntriesPath=$(CUSTOM_ENTRIES_PATH) --customEntriesFormat=$(CUSTOM_ENTRIES_FORMAT) --host-open-ports $(if $(DEBUG),--debug=true)
 
-  
 .PHONY: install
 install:
 	install $(EXECUTABLE) $(INSTALL_DIR)

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -43,7 +43,6 @@ Usage:
   oc commatrix generate [flags]
 
 Flags:
-      --platform-type string         Platform Type (baremetal, aws), Required
       --customEntriesFormat string   Set the format of the custom entries file (json,yaml,csv)
       --customEntriesPath string     Add custom entries from a file to the matrix
       --debug                        Debug logs (default is false)
@@ -59,11 +58,10 @@ Once you run the `oc commatrix generate` command, the plugin will
 generate a communication matrix based on the ingress flows in your
 OpenShift cluster. The output will be saved to a file (destDir) in the chosen format,
 similar to the following:
-> **Note:** The `--platform-type` flag is required for all commands.
 
-`csv example on aws`
+`csv example`
 ```sh
-$ oc commatrix generate --format csv --platform-type aws
+$ oc commatrix generate --format csv
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,22,Host system service,sshd,,,master,true
 Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,false
@@ -71,9 +69,9 @@ Ingress,TCP,80,openshift-ingress,router-internal-default,router-default,router,m
 Ingress,TCP,111,Host system service,rpcbind,,,master,true
 ```
 
-`json example on baremetal`
+`json example`
 ```sh
-$ oc commatrix generate --format json --platform-type baremetal
+$ oc commatrix generate --format json
 [
     {
         "direction": "Ingress",
@@ -100,9 +98,9 @@ $ oc commatrix generate --format json --platform-type baremetal
 ]
 ```
 
-`host-open-ports example command on aws`
+`host-open-ports example command`
 ```sh
-$ oc commatrix generate --platform-type aws --host-open-ports --format csv
+$ oc commatrix generate --host-open-ports --format csv
 ```
 
 the command will generate the follwing paths:
@@ -153,9 +151,9 @@ UNCONN 0      0      127.0.0.1:323   0.0.0.0:* users:(("chronyd",pid=2805,fd=5))
 UNCONN 0      0      127.0.0.1:708   0.0.0.0:* users:(("rpc.statd",pid=3922,fd=8))
 ```
 
-`customEntriesFormat and customEntriesPath example command on baremetal`
+`customEntriesFormat and customEntriesPath example command`
 ```sh
-$ oc commatrix generate --platform-type baremetal --format csv --customEntriesFormat csv --customEntriesPath "communication-matrix/customEntriesPath"
+$ oc commatrix generate --format csv --customEntriesFormat csv --customEntriesPath "communication-matrix/customEntriesPath"
 ```
 
 `contents of communication-matrix/customEntriesPath`

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -156,7 +156,7 @@ func TestCommatrixGeneration(t *testing.T) {
 	}{
 		{
 			name: "Should generate CSV output",
-			args: []string{"generate", "--format", "csv", "--destDir", destDir, "--platform-type", "aws"},
+			args: []string{"generate", "--format", "csv", "--destDir", destDir},
 			expectedFunc: func() (string, error) {
 				expectedOutput, err := expectedComMatrix.ToCSV()
 				return string(expectedOutput), err
@@ -165,7 +165,7 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should generate JSON output",
-			args: []string{"generate", "--format", "json", "--destDir", destDir, "--platform-type", "aws"},
+			args: []string{"generate", "--format", "json", "--destDir", destDir},
 			expectedFunc: func() (string, error) {
 				expectedOutput, err := expectedComMatrix.ToJSON()
 				return string(expectedOutput), err
@@ -173,24 +173,8 @@ func TestCommatrixGeneration(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Should Return failure on misssing platform-type",
-			args: []string{"generate"},
-			expectedFunc: func() (string, error) {
-				return "", fmt.Errorf("required flag(s) \"platform-type\" not set")
-			},
-			wantErr: true,
-		},
-		{
-			name: "Should Return failure on platform-type validation",
-			args: []string{"generate", "--platform-type", "test"},
-			expectedFunc: func() (string, error) {
-				return "", fmt.Errorf("invalid platform type test, valid options: [baremetal aws]")
-			},
-			wantErr: true,
-		},
-		{
 			name: "Should Return failure on format validation",
-			args: []string{"generate", "--format", "test", "--platform-type", "aws"},
+			args: []string{"generate", "--format", "test"},
 			expectedFunc: func() (string, error) {
 				return "", fmt.Errorf("invalid format 'test', valid options are: csv, json, yaml, nft")
 			},
@@ -198,7 +182,7 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should return failure when customEntriesPath is set but customEntriesFormat is missing",
-			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--platform-type", "aws"},
+			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile"},
 			expectedFunc: func() (string, error) {
 				return "", fmt.Errorf("you must specify the --customEntriesFormat when using --customEntriesPath")
 			},
@@ -206,7 +190,7 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should return failure when customEntriesFormat is set but customEntriesPath is missing",
-			args: []string{"generate", "--customEntriesFormat", "nft", "--platform-type", "aws"},
+			args: []string{"generate", "--customEntriesFormat", "nft"},
 			expectedFunc: func() (string, error) {
 				return "", fmt.Errorf("you must specify the --customEntriesPath when using --customEntriesFormat")
 			},
@@ -214,7 +198,7 @@ func TestCommatrixGeneration(t *testing.T) {
 		},
 		{
 			name: "Should return failure when customEntriesFormat not valid",
-			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--customEntriesFormat", "invalid", "--platform-type", "aws"},
+			args: []string{"generate", "--customEntriesPath", "/path/to/customEntriesFile", "--customEntriesFormat", "invalid"},
 			expectedFunc: func() (string, error) {
 				return "", fmt.Errorf("invalid custom entries format 'invalid', valid options are: csv, json, yaml")
 			},

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -10,22 +10,23 @@ import (
 
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 type CommunicationMatrixCreator struct {
 	exporter            *endpointslices.EndpointSlicesExporter
 	customEntriesPath   string
 	customEntriesFormat string
-	e                   types.Env
+	platformType        configv1.PlatformType
 	d                   types.Deployment
 }
 
-func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, e types.Env, d types.Deployment) (*CommunicationMatrixCreator, error) {
+func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, d types.Deployment) (*CommunicationMatrixCreator, error) {
 	return &CommunicationMatrixCreator{
 		exporter:            exporter,
 		customEntriesPath:   customEntriesPath,
 		customEntriesFormat: customEntriesFormat,
-		e:                   e,
+		platformType:        platformType,
 		d:                   d,
 	}, nil
 }
@@ -106,23 +107,25 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 	log.Debug("Determining static entries based on environment and deployment")
 	comDetails := []types.ComDetails{}
 
-	switch cm.e {
-	case types.Baremetal:
+	switch cm.platformType {
+	case configv1.BareMetalPlatformType:
 		log.Debug("Adding Baremetal static entries")
 		comDetails = append(comDetails, types.BaremetalStaticEntriesMaster...)
 		if cm.d == types.SNO {
 			break
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
-	case types.Cloud:
+	case configv1.AWSPlatformType:
 		log.Debug("Adding Cloud static entries")
 		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
 		if cm.d == types.SNO {
 			break
 		}
 		comDetails = append(comDetails, types.CloudStaticEntriesWorker...)
+	case configv1.NonePlatformType:
+		break
 	default:
-		log.Errorf("Invalid value for cluster environment: %v", cm.e)
+		log.Errorf("Invalid value for cluster environment: %v", cm.platformType)
 		return nil, fmt.Errorf("invalid value for cluster environment")
 	}
 

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -18,16 +18,16 @@ type CommunicationMatrixCreator struct {
 	customEntriesPath   string
 	customEntriesFormat string
 	platformType        configv1.PlatformType
-	d                   types.Deployment
+	deployment          types.Deployment
 }
 
-func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, d types.Deployment) (*CommunicationMatrixCreator, error) {
+func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, deployment types.Deployment) (*CommunicationMatrixCreator, error) {
 	return &CommunicationMatrixCreator{
 		exporter:            exporter,
 		customEntriesPath:   customEntriesPath,
 		customEntriesFormat: customEntriesFormat,
 		platformType:        platformType,
-		d:                   d,
+		deployment:          deployment,
 	}, nil
 }
 
@@ -111,14 +111,14 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 	case configv1.BareMetalPlatformType:
 		log.Debug("Adding Baremetal static entries")
 		comDetails = append(comDetails, types.BaremetalStaticEntriesMaster...)
-		if cm.d == types.SNO {
+		if cm.deployment == types.SNO {
 			break
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
 	case configv1.AWSPlatformType:
 		log.Debug("Adding Cloud static entries")
 		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
-		if cm.d == types.SNO {
+		if cm.deployment == types.SNO {
 			break
 		}
 		comDetails = append(comDetails, types.CloudStaticEntriesWorker...)
@@ -131,7 +131,7 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 
 	log.Debug("Adding general static entries")
 	comDetails = append(comDetails, types.GeneralStaticEntriesMaster...)
-	if cm.d == types.SNO {
+	if cm.deployment == types.SNO {
 		return comDetails, nil
 	}
 

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -114,7 +114,7 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 			break
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
-	case types.AWS:
+	case types.Cloud:
 		log.Debug("Adding Cloud static entries")
 		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
 		if cm.d == types.SNO {

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -231,7 +231,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud standard cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud standard cluster")
-			cm, err := New(nil, "", "", types.AWS, types.Standard)
+			cm, err := New(nil, "", "", types.Cloud, types.Standard)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -246,7 +246,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud SNO cluster")
-			cm, err := New(nil, "", "", types.AWS, types.SNO)
+			cm, err := New(nil, "", "", types.Cloud, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -296,7 +296,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix with custom entries", func() {
 			g.By("Creating new communication matrix with static entries")
-			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, types.AWS, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, types.Cloud, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -320,7 +320,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
 			g.By("Creating new communication matrix without static entries")
-			commatrixCreator, err := New(endpointSlices, "", "", types.AWS, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "", "", types.Cloud, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	matrixdiff "github.com/openshift-kni/commatrix/pkg/matrix-diff"
 	"github.com/openshift-kni/commatrix/pkg/types"
+	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek "k8s.io/client-go/kubernetes/fake"
 )
@@ -160,7 +161,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 		for _, format := range []string{types.FormatCSV, types.FormatJSON, types.FormatYAML} {
 			g.It(fmt.Sprintf("Should successfully extract ComDetails from a %s file", format), func() {
 				g.By(fmt.Sprintf("Creating new communication matrix with %s static entries format", format))
-				cm, err := New(nil, fmt.Sprintf("../../samples/custom-entries/example-custom-entries.%s", format), format, 0, 0)
+				cm, err := New(nil, fmt.Sprintf("../../samples/custom-entries/example-custom-entries.%s", format), format, configv1.BareMetalPlatformType, 0)
 				o.Expect(err).ToNot(o.HaveOccurred())
 
 				g.By("Getting ComDetails List From File")
@@ -174,7 +175,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to non-matched customEntriesPath and customEntriesFormat types", func() {
 			g.By("Creating new communication matrix with non-matched customEntriesPath and customEntriesFormat")
-			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatJSON, 0, 0)
+			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatJSON, configv1.BareMetalPlatformType, 0)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComDetails List From File")
@@ -187,7 +188,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid customEntriesFormat", func() {
 			g.By("Creating new communication matrix with invalid customEntriesFormat")
-			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatNFT, 0, 0)
+			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatNFT, configv1.BareMetalPlatformType, 0)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComDetails List From File")
@@ -202,7 +203,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 	g.Context("Get static entries from file", func() {
 		g.It("Should successfully get static entries suitable to baremetal standard cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal standard cluster")
-			cm, err := New(nil, "", "", types.Baremetal, types.Standard)
+			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, types.Standard)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -217,7 +218,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to baremetal SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal SNO cluster")
-			cm, err := New(nil, "", "", types.Baremetal, types.SNO)
+			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -231,7 +232,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud standard cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud standard cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.Standard)
+			cm, err := New(nil, "", "", configv1.AWSPlatformType, types.Standard)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -246,7 +247,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud SNO cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.SNO)
+			cm, err := New(nil, "", "", configv1.AWSPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -260,7 +261,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid value for cluster environment", func() {
 			g.By("Creating new communication matrix with an invalid value for cluster environment")
-			cm, err := New(nil, "", "", -1, types.SNO)
+			cm, err := New(nil, "", "", "invalid", types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -296,7 +297,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix with custom entries", func() {
 			g.By("Creating new communication matrix with static entries")
-			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, types.Cloud, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, configv1.AWSPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -320,7 +321,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
 			g.By("Creating new communication matrix without static entries")
-			commatrixCreator, err := New(endpointSlices, "", "", types.Cloud, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "", "", configv1.AWSPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,13 +20,6 @@ import (
 	"github.com/openshift-kni/commatrix/pkg/utils"
 )
 
-type Env int
-
-const (
-	Baremetal Env = iota
-	Cloud
-)
-
 type Deployment int
 
 const (
@@ -65,17 +58,6 @@ type ContainerInfo struct {
 			PodNamespace  string `json:"io.kubernetes.pod.namespace"`
 		} `json:"labels"`
 	} `json:"containers"`
-}
-
-func GetEnv(envStr string) (Env, error) {
-	switch envStr {
-	case "baremetal":
-		return Baremetal, nil
-	case "cloud":
-		return Cloud, nil
-	default:
-		return -1, fmt.Errorf("invalid cluster environment: %s", envStr)
-	}
 }
 
 func GetDeployment(deploymentStr string) (Deployment, error) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -24,7 +24,7 @@ type Env int
 
 const (
 	Baremetal Env = iota
-	AWS
+	Cloud
 )
 
 type Deployment int
@@ -71,8 +71,8 @@ func GetEnv(envStr string) (Env, error) {
 	switch envStr {
 	case "baremetal":
 		return Baremetal, nil
-	case "aws":
-		return AWS, nil
+	case "cloud":
+		return Cloud, nil
 	default:
 		return -1, fmt.Errorf("invalid cluster environment: %s", envStr)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -60,17 +60,6 @@ type ContainerInfo struct {
 	} `json:"containers"`
 }
 
-func GetDeployment(deploymentStr string) (Deployment, error) {
-	switch deploymentStr {
-	case "standard":
-		return Standard, nil
-	case "sno":
-		return SNO, nil
-	default:
-		return -1, fmt.Errorf("invalid deployment type: %s", deploymentStr)
-	}
-}
-
 func (m *ComMatrix) ToCSV() ([]byte, error) {
 	out := make([]byte, 0)
 	w := bytes.NewBuffer(out)

--- a/pkg/utils/mock/mock_utils.go
+++ b/pkg/utils/mock/mock_utils.go
@@ -8,7 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/openshift/api/config/v1"
+	v10 "k8s.io/api/core/v1"
 )
 
 // MockUtilsInterface is a mock of UtilsInterface interface.
@@ -49,10 +50,10 @@ func (mr *MockUtilsInterfaceMockRecorder) CreateNamespace(namespace interface{})
 }
 
 // CreatePodOnNode mocks base method.
-func (m *MockUtilsInterface) CreatePodOnNode(nodeName, namespace, image string, command []string) (*v1.Pod, error) {
+func (m *MockUtilsInterface) CreatePodOnNode(nodeName, namespace, image string, command []string) (*v10.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePodOnNode", nodeName, namespace, image, command)
-	ret0, _ := ret[0].(*v1.Pod)
+	ret0, _ := ret[0].(*v10.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -78,7 +79,7 @@ func (mr *MockUtilsInterfaceMockRecorder) DeleteNamespace(namespace interface{})
 }
 
 // DeletePod mocks base method.
-func (m *MockUtilsInterface) DeletePod(pod *v1.Pod) error {
+func (m *MockUtilsInterface) DeletePod(pod *v10.Pod) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePod", pod)
 	ret0, _ := ret[0].(error)
@@ -91,8 +92,23 @@ func (mr *MockUtilsInterfaceMockRecorder) DeletePod(pod interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockUtilsInterface)(nil).DeletePod), pod)
 }
 
+// GetPlatformType mocks base method.
+func (m *MockUtilsInterface) GetPlatformType() (v1.PlatformType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlatformType")
+	ret0, _ := ret[0].(v1.PlatformType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPlatformType indicates an expected call of GetPlatformType.
+func (mr *MockUtilsInterfaceMockRecorder) GetPlatformType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlatformType", reflect.TypeOf((*MockUtilsInterface)(nil).GetPlatformType))
+}
+
 // GetPodLogs mocks base method.
-func (m *MockUtilsInterface) GetPodLogs(namespace string, pod *v1.Pod) (string, error) {
+func (m *MockUtilsInterface) GetPodLogs(namespace string, pod *v10.Pod) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPodLogs", namespace, pod)
 	ret0, _ := ret[0].(string)
@@ -104,21 +120,6 @@ func (m *MockUtilsInterface) GetPodLogs(namespace string, pod *v1.Pod) (string, 
 func (mr *MockUtilsInterfaceMockRecorder) GetPodLogs(namespace, pod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockUtilsInterface)(nil).GetPodLogs), namespace, pod)
-}
-
-// IsBMInfra mocks base method.
-func (m *MockUtilsInterface) IsBMInfra() (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsBMInfra")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsBMInfra indicates an expected call of IsBMInfra.
-func (mr *MockUtilsInterfaceMockRecorder) IsBMInfra() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBMInfra", reflect.TypeOf((*MockUtilsInterface)(nil).IsBMInfra))
 }
 
 // IsSNOCluster mocks base method.
@@ -137,7 +138,7 @@ func (mr *MockUtilsInterfaceMockRecorder) IsSNOCluster() *gomock.Call {
 }
 
 // RunCommandOnPod mocks base method.
-func (m *MockUtilsInterface) RunCommandOnPod(pod *v1.Pod, command []string) ([]byte, error) {
+func (m *MockUtilsInterface) RunCommandOnPod(pod *v10.Pod, command []string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunCommandOnPod", pod, command)
 	ret0, _ := ret[0].([]byte)
@@ -152,7 +153,7 @@ func (mr *MockUtilsInterfaceMockRecorder) RunCommandOnPod(pod, command interface
 }
 
 // WaitForPodStatus mocks base method.
-func (m *MockUtilsInterface) WaitForPodStatus(namespace string, pod *v1.Pod, PodPhase v1.PodPhase) error {
+func (m *MockUtilsInterface) WaitForPodStatus(namespace string, pod *v10.Pod, PodPhase v10.PodPhase) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForPodStatus", namespace, pod, PodPhase)
 	ret0, _ := ret[0].(error)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/commatrix/pkg/client"
 	"github.com/openshift-kni/commatrix/pkg/utils"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -48,8 +49,15 @@ var _ = BeforeSuite(func() {
 	isSNO, err = utilsHelpers.IsSNOCluster()
 	Expect(err).NotTo(HaveOccurred())
 
-	isBM, err = utilsHelpers.IsBMInfra()
+	platformType, err := utilsHelpers.GetPlatformType()
 	Expect(err).NotTo(HaveOccurred())
+
+	isBM = false
+	// Assuming Telco partners use 'None' platform type just on Bare Metal.
+	// Mark as Bare Metal if the platform type is either 'BareMetal' (multi-node BM) or 'None' (SNO BM).
+	if platformType == configv1.BareMetalPlatformType || platformType == configv1.NonePlatformType {
+		isBM = true
+	}
 })
 
 func TestE2e(t *testing.T) {


### PR DESCRIPTION
We originally introduced the PLATFORM_TYPE environment variable to handle cases where the platform type was None. However, None is a valid platform type on its own and should not be interpreted as either a cloud or baremetal platform.

Therefore, we are removing all usage of the PLATFORM_TYPE variable and will rely solely on the existing functions that detect the platform type automatically.

update the code to handle the none platfrom type:
- on case of test need to compare the none sno to the bm sno
- on the static entries no need to add for none
- remove the env iota var and use the configv1 var
- supported telco cases for now are (bm sno thats none and bm mno and the aws)

change the d var to be deployment a clear name