### PR TITLE
Remove ports 10300 and 10390 from doc commatrix and static entries

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -142,7 +142,7 @@ var (
 )
 
 func TestCommatrixGeneration(t *testing.T) {
-	expectedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster, types.CloudStaticEntriesWorker,
+	expectedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster,
 		types.GeneralStaticEntriesMaster, types.GeneralStaticEntriesWorker, types.StandardStaticEntries)
 
 	expectedComMatrix := types.ComMatrix{Matrix: expectedComDetails}

--- a/docs/stable/raw/aws-sno.csv
+++ b/docs/stable/raw/aws-sno.csv
@@ -30,8 +30,6 @@ Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/raw/aws.csv
+++ b/docs/stable/raw/aws.csv
@@ -28,8 +28,6 @@ Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
@@ -50,7 +48,5 @@ Ingress,TCP,9537,Host system service,crio-metrics,,,worker,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,worker,FALSE
 Ingress,TCP,10250,Host system service,kubelet,,,worker,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,worker,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,worker,FALSE
 Ingress,UDP,111,Host system service,rpcbind,,,worker,TRUE
 Ingress,UDP,6081,openshift-ovn-kubernetes,ovn-kubernetes geneve,,,worker,FALSE

--- a/docs/stable/raw/bm-sno.csv
+++ b/docs/stable/raw/bm-sno.csv
@@ -31,8 +31,6 @@ Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/unique/aws-sno.csv
+++ b/docs/stable/unique/aws-sno.csv
@@ -3,5 +3,3 @@ Ingress,TCP,80,openshift-ingress,router-default,router-default,router,master,FAL
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE

--- a/docs/stable/unique/aws.csv
+++ b/docs/stable/unique/aws.csv
@@ -1,9 +1,5 @@
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
 Ingress,TCP,80,openshift-ingress,router-default,router-default,router,worker,FALSE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,worker,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,worker,FALSE

--- a/docs/stable/unique/bm-sno.csv
+++ b/docs/stable/unique/bm-sno.csv
@@ -4,5 +4,3 @@ Ingress,TCP,443,openshift-ingress,router-internal-default,router-default,router,
 Ingress,TCP,1936,openshift-ingress,router-internal-default,router-default,router,master,FALSE
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -118,10 +118,6 @@ func (cm *CommunicationMatrixCreator) GetStaticEntries() ([]types.ComDetails, er
 	case configv1.AWSPlatformType:
 		log.Debug("Adding Cloud static entries")
 		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
-		if cm.deployment == types.SNO {
-			break
-		}
-		comDetails = append(comDetails, types.CloudStaticEntriesWorker...)
 	case configv1.NonePlatformType:
 		break
 	default:

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -240,8 +240,8 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to wanted comDetails")
-			wantedComDetails := slices.Concat(types.CloudStaticEntriesMaster, types.CloudStaticEntriesWorker,
-				types.GeneralStaticEntriesMaster, types.StandardStaticEntries, types.GeneralStaticEntriesWorker)
+			wantedComDetails := slices.Concat(types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster,
+				types.StandardStaticEntries, types.GeneralStaticEntriesWorker)
 			o.Expect(gotComDetails).To(o.Equal(wantedComDetails))
 		})
 

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -366,30 +366,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	},
 }
 
-var CloudStaticEntriesWorker = []ComDetails{
-	{
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10300,
-		NodeRole:  "worker",
-		Service:   "csi-livenessprobe",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-driver",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10309,
-		NodeRole:  "worker",
-		Service:   "csi-node-driver",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-node-driver-registrar",
-		Optional:  false,
-	},
-}
-
 var CloudStaticEntriesMaster = []ComDetails{
 	{
 		Direction: "Ingress",
@@ -410,26 +386,6 @@ var CloudStaticEntriesMaster = []ComDetails{
 		Namespace: "openshift-cloud-controller-manager-operator",
 		Pod:       "cloud-controller-manager",
 		Container: "cloud-controller-manager",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10300,
-		NodeRole:  "master",
-		Service:   "csi-livenessprobe",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-driver",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10309,
-		NodeRole:  "master",
-		Service:   "csi-node-driver",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-node-driver-registrar",
 		Optional:  false,
 	},
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -116,7 +116,6 @@ var _ = Describe("Validation", func() {
 		// if cluster is running on BM exclude Cloud static entries in diff generation
 		// else cluster is running on Cloud and exclude BM static entries in diff generation.
 		if isBM {
-			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.CloudStaticEntriesWorker}, "worker")
 			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.CloudStaticEntriesMaster}, "master")
 		} else {
 			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.BaremetalStaticEntriesWorker}, "worker")


### PR DESCRIPTION
Ports 10300, 10390 had been changed to be used only internally and there for shouldn't be documented in the communication matrix (see resolved [JIRA bug](https://issues.redhat.com/browse/OCPBUGS-50493), and [PR](https://github.com/openshift/csi-operator/pull/364) converting the ports to internal use)

Note: `types.CloudStaticEntriesWorker` was deleted as it only contained the above ports.