### PR TITLE
[release-4.18] handle the noneplatformtype platform on 4.18

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,14 +63,9 @@ func main() {
 	}
 
 	log.Debug("Get infra type")
-	infra := types.Cloud
-	isBM, err := utilsHelpers.IsBMInfra()
+	platformType, err := utilsHelpers.GetPlatformType()
 	if err != nil {
 		log.Panicf("Failed to get infra type %v", err)
-	}
-
-	if isBM {
-		infra = types.Baremetal
 	}
 
 	epExporter, err := endpointslices.New(cs)
@@ -80,7 +75,7 @@ func main() {
 	log.Debug("EndpointSlices exporter created")
 
 	log.Debug("Creating communication matrix")
-	commMatrix, err := commatrixcreator.New(epExporter, customEntriesPath, customEntriesFormat, infra, deployment)
+	commMatrix, err := commatrixcreator.New(epExporter, customEntriesPath, customEntriesFormat, platformType, deployment)
 	if err != nil {
 		log.Panicf("Failed creating comm matrix creator: %v", err)
 	}

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -13,23 +13,24 @@ import (
 
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 type CommunicationMatrixCreator struct {
 	exporter            *endpointslices.EndpointSlicesExporter
 	customEntriesPath   string
 	customEntriesFormat string
-	e                   types.Env
-	d                   types.Deployment
+	platformType        configv1.PlatformType
+	deployment          types.Deployment
 }
 
-func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, e types.Env, d types.Deployment) (*CommunicationMatrixCreator, error) {
+func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, deployment types.Deployment) (*CommunicationMatrixCreator, error) {
 	return &CommunicationMatrixCreator{
 		exporter:            exporter,
 		customEntriesPath:   customEntriesPath,
 		customEntriesFormat: customEntriesFormat,
-		e:                   e,
-		d:                   d,
+		platformType:        platformType,
+		deployment:          deployment,
 	}, nil
 }
 
@@ -128,29 +129,31 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 	log.Debug("Determining static entries based on environment and deployment")
 	comDetails := []types.ComDetails{}
 
-	switch cm.e {
-	case types.Baremetal:
+	switch cm.platformType {
+	case configv1.BareMetalPlatformType:
 		log.Debug("Adding Baremetal static entries")
 		comDetails = append(comDetails, types.BaremetalStaticEntriesMaster...)
-		if cm.d == types.SNO {
+		if cm.deployment == types.SNO {
 			break
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
-	case types.Cloud:
+	case configv1.AWSPlatformType:
 		log.Debug("Adding Cloud static entries")
 		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
-		if cm.d == types.SNO {
+		if cm.deployment == types.SNO {
 			break
 		}
 		comDetails = append(comDetails, types.CloudStaticEntriesWorker...)
+	case configv1.NonePlatformType:
+		break
 	default:
-		log.Errorf("Invalid value for cluster environment: %v", cm.e)
+		log.Errorf("Invalid value for cluster environment: %v", cm.platformType)
 		return nil, fmt.Errorf("invalid value for cluster environment")
 	}
 
 	log.Debug("Adding general static entries")
 	comDetails = append(comDetails, types.GeneralStaticEntriesMaster...)
-	if cm.d == types.SNO {
+	if cm.deployment == types.SNO {
 		return comDetails, nil
 	}
 

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	matrixdiff "github.com/openshift-kni/commatrix/pkg/matrix-diff"
 	"github.com/openshift-kni/commatrix/pkg/types"
+	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek "k8s.io/client-go/kubernetes/fake"
 )
@@ -160,7 +161,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 		for _, format := range []string{types.FormatCSV, types.FormatJSON, types.FormatYAML} {
 			g.It(fmt.Sprintf("Should successfully extract ComDetails from a %s file", format), func() {
 				g.By(fmt.Sprintf("Creating new communication matrix with %s static entries format", format))
-				cm, err := New(nil, fmt.Sprintf("../../samples/custom-entries/example-custom-entries.%s", format), format, 0, 0)
+				cm, err := New(nil, fmt.Sprintf("../../samples/custom-entries/example-custom-entries.%s", format), format, configv1.BareMetalPlatformType, 0)
 				o.Expect(err).ToNot(o.HaveOccurred())
 
 				g.By("Getting ComDetails List From File")
@@ -174,7 +175,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to non-matched customEntriesPath and customEntriesFormat types", func() {
 			g.By("Creating new communication matrix with non-matched customEntriesPath and customEntriesFormat")
-			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatJSON, 0, 0)
+			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatJSON, configv1.BareMetalPlatformType, 0)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComDetails List From File")
@@ -187,7 +188,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid customEntriesFormat", func() {
 			g.By("Creating new communication matrix with invalid customEntriesFormat")
-			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatNFT, 0, 0)
+			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatNFT, configv1.BareMetalPlatformType, 0)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComDetails List From File")
@@ -202,7 +203,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 	g.Context("Get static entries from file", func() {
 		g.It("Should successfully get static entries suitable to baremetal standard cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal standard cluster")
-			cm, err := New(nil, "", "", types.Baremetal, types.Standard)
+			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, types.Standard)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -217,7 +218,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to baremetal SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal SNO cluster")
-			cm, err := New(nil, "", "", types.Baremetal, types.SNO)
+			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -231,7 +232,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud standard cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud standard cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.Standard)
+			cm, err := New(nil, "", "", configv1.AWSPlatformType, types.Standard)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -246,7 +247,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to cloud SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to cloud SNO cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.SNO)
+			cm, err := New(nil, "", "", configv1.AWSPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -260,7 +261,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid value for cluster environment", func() {
 			g.By("Creating new communication matrix with an invalid value for cluster environment")
-			cm, err := New(nil, "", "", -1, types.SNO)
+			cm, err := New(nil, "", "", "invalid", types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -296,7 +297,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix with custom entries", func() {
 			g.By("Creating new communication matrix with static entries")
-			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, types.Cloud, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, configv1.AWSPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -320,7 +321,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
 			g.By("Creating new communication matrix without static entries")
-			commatrixCreator, err := New(endpointSlices, "", "", types.Cloud, types.SNO)
+			commatrixCreator, err := New(endpointSlices, "", "", configv1.AWSPlatformType, types.SNO)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,13 +20,6 @@ import (
 	"github.com/openshift-kni/commatrix/pkg/utils"
 )
 
-type Env int
-
-const (
-	Baremetal Env = iota
-	Cloud
-)
-
 type Deployment int
 
 const (
@@ -65,28 +58,6 @@ type ContainerInfo struct {
 			PodNamespace  string `json:"io.kubernetes.pod.namespace"`
 		} `json:"labels"`
 	} `json:"containers"`
-}
-
-func GetEnv(envStr string) (Env, error) {
-	switch envStr {
-	case "baremetal":
-		return Baremetal, nil
-	case "cloud":
-		return Cloud, nil
-	default:
-		return -1, fmt.Errorf("invalid cluster environment: %s", envStr)
-	}
-}
-
-func GetDeployment(deploymentStr string) (Deployment, error) {
-	switch deploymentStr {
-	case "standard":
-		return Standard, nil
-	case "sno":
-		return SNO, nil
-	default:
-		return -1, fmt.Errorf("invalid deployment type: %s", deploymentStr)
-	}
 }
 
 func (m *ComMatrix) ToCSV() ([]byte, error) {

--- a/pkg/utils/mock/mock_utils.go
+++ b/pkg/utils/mock/mock_utils.go
@@ -8,7 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/openshift/api/config/v1"
+	v10 "k8s.io/api/core/v1"
 )
 
 // MockUtilsInterface is a mock of UtilsInterface interface.
@@ -49,10 +50,10 @@ func (mr *MockUtilsInterfaceMockRecorder) CreateNamespace(namespace interface{})
 }
 
 // CreatePodOnNode mocks base method.
-func (m *MockUtilsInterface) CreatePodOnNode(nodeName, namespace, image string, command []string) (*v1.Pod, error) {
+func (m *MockUtilsInterface) CreatePodOnNode(nodeName, namespace, image string, command []string) (*v10.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePodOnNode", nodeName, namespace, image, command)
-	ret0, _ := ret[0].(*v1.Pod)
+	ret0, _ := ret[0].(*v10.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -78,7 +79,7 @@ func (mr *MockUtilsInterfaceMockRecorder) DeleteNamespace(namespace interface{})
 }
 
 // DeletePod mocks base method.
-func (m *MockUtilsInterface) DeletePod(pod *v1.Pod) error {
+func (m *MockUtilsInterface) DeletePod(pod *v10.Pod) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePod", pod)
 	ret0, _ := ret[0].(error)
@@ -91,8 +92,23 @@ func (mr *MockUtilsInterfaceMockRecorder) DeletePod(pod interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockUtilsInterface)(nil).DeletePod), pod)
 }
 
+// GetPlatformType mocks base method.
+func (m *MockUtilsInterface) GetPlatformType() (v1.PlatformType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlatformType")
+	ret0, _ := ret[0].(v1.PlatformType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPlatformType indicates an expected call of GetPlatformType.
+func (mr *MockUtilsInterfaceMockRecorder) GetPlatformType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlatformType", reflect.TypeOf((*MockUtilsInterface)(nil).GetPlatformType))
+}
+
 // GetPodLogs mocks base method.
-func (m *MockUtilsInterface) GetPodLogs(namespace string, pod *v1.Pod) (string, error) {
+func (m *MockUtilsInterface) GetPodLogs(namespace string, pod *v10.Pod) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPodLogs", namespace, pod)
 	ret0, _ := ret[0].(string)
@@ -104,21 +120,6 @@ func (m *MockUtilsInterface) GetPodLogs(namespace string, pod *v1.Pod) (string, 
 func (mr *MockUtilsInterfaceMockRecorder) GetPodLogs(namespace, pod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockUtilsInterface)(nil).GetPodLogs), namespace, pod)
-}
-
-// IsBMInfra mocks base method.
-func (m *MockUtilsInterface) IsBMInfra() (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsBMInfra")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsBMInfra indicates an expected call of IsBMInfra.
-func (mr *MockUtilsInterfaceMockRecorder) IsBMInfra() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBMInfra", reflect.TypeOf((*MockUtilsInterface)(nil).IsBMInfra))
 }
 
 // IsSNOCluster mocks base method.
@@ -137,7 +138,7 @@ func (mr *MockUtilsInterfaceMockRecorder) IsSNOCluster() *gomock.Call {
 }
 
 // RunCommandOnPod mocks base method.
-func (m *MockUtilsInterface) RunCommandOnPod(pod *v1.Pod, command []string) ([]byte, error) {
+func (m *MockUtilsInterface) RunCommandOnPod(pod *v10.Pod, command []string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunCommandOnPod", pod, command)
 	ret0, _ := ret[0].([]byte)
@@ -152,7 +153,7 @@ func (mr *MockUtilsInterfaceMockRecorder) RunCommandOnPod(pod, command interface
 }
 
 // WaitForPodStatus mocks base method.
-func (m *MockUtilsInterface) WaitForPodStatus(namespace string, pod *v1.Pod, PodPhase v1.PodPhase) error {
+func (m *MockUtilsInterface) WaitForPodStatus(namespace string, pod *v10.Pod, PodPhase v10.PodPhase) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForPodStatus", namespace, pod, PodPhase)
 	ret0, _ := ret[0].(error)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
 	"github.com/openshift-kni/commatrix/pkg/utils"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -23,11 +24,11 @@ var (
 	isSNO        bool
 	isBM         bool
 	deployment   types.Deployment
-	infra        types.Env
 	utilsHelpers utils.UtilsInterface
 	epExporter   *endpointslices.EndpointSlicesExporter
 	nodeList     *corev1.NodeList
 	artifactsDir string
+	platformType configv1.PlatformType
 )
 
 const testNS = "openshift-commatrix-test"
@@ -62,19 +63,21 @@ var _ = BeforeSuite(func() {
 		deployment = types.SNO
 	}
 
-	infra = types.Cloud
-	isBM, err = utilsHelpers.IsBMInfra()
+	platformType, err = utilsHelpers.GetPlatformType()
 	Expect(err).NotTo(HaveOccurred())
 
-	if isBM {
-		infra = types.Baremetal
+	isBM = false
+	// Assuming Telco partners use 'None' platform type just on Bare Metal.
+	// Mark as Bare Metal if the platform type is either 'BareMetal' (multi-node BM) or 'None' (SNO BM).
+	if platformType == configv1.BareMetalPlatformType || platformType == configv1.NonePlatformType {
+		isBM = true
 	}
 
 	epExporter, err = endpointslices.New(cs)
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Generating comMatrix")
-	commMatrixCreator, err := commatrixcreator.New(epExporter, "", "", infra, deployment)
+	commMatrixCreator, err := commatrixcreator.New(epExporter, "", "", platformType, deployment)
 	Expect(err).NotTo(HaveOccurred())
 
 	commatrix, err = commMatrixCreator.CreateEndpointMatrix()

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Validation", func() {
 
 		By(fmt.Sprintf("Filter documented commatrix type %s for diff generation", docType))
 		// get origin documented commatrix details
-		docComMatrixCreator, err := commatrixcreator.New(epExporter, docCommatrixFilePath, types.FormatCSV, infra, deployment)
+		docComMatrixCreator, err := commatrixcreator.New(epExporter, docCommatrixFilePath, types.FormatCSV, platformType, deployment)
 		Expect(err).ToNot(HaveOccurred())
 		docComDetailsList, err := docComMatrixCreator.GetComDetailsListFromFile()
 		Expect(err).ToNot(HaveOccurred())
@@ -123,7 +123,7 @@ var _ = Describe("Validation", func() {
 		missingPortsMat := endpointslicesDiffWithDocMat.GenerateUniquePrimary()
 		if openPortsToIgnoreFile != "" && openPortsToIgnoreFormat != "" {
 			// generate open ports to ignore commatrix
-			portsToIgnoreCommatrixCreator, err := commatrixcreator.New(epExporter, openPortsToIgnoreFile, openPortsToIgnoreFormat, infra, deployment)
+			portsToIgnoreCommatrixCreator, err := commatrixcreator.New(epExporter, openPortsToIgnoreFile, openPortsToIgnoreFormat, platformType, deployment)
 			Expect(err).ToNot(HaveOccurred())
 			portsToIgnoreComDetails, err := portsToIgnoreCommatrixCreator.GetComDetailsListFromFile()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
- remove the itoa env var, no need for it and use the configv1 var 
- update the function of the platform type to get the type and if not suppourted to show relevant error 
- ensured that static entries are not created for None platform type. 
- update the deployment var name from d to be deployment, to consistenty with the other paramters and remove the unused function
cherry pick from https://github.com/openshift-kni/commatrix/pull/124