### PR TITLE
Update bm sno commatrix to match sno none type cluster

### DIFF
--- a/docs/stable/raw/bm-sno.csv
+++ b/docs/stable/raw/bm-sno.csv
@@ -28,9 +28,7 @@ Ingress,TCP,9980,openshift-etcd,etcd,etcd,etcd,master,FALSE
 Ingress,TCP,10250,Host system service,kubelet,,,master,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,master,FALSE
 Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube-controller-manager,kube-controller-manager,master,FALSE
-Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
-Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/unique/bm-sno.csv
+++ b/docs/stable/unique/bm-sno.csv
@@ -2,5 +2,3 @@ Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,80,openshift-ingress,router-internal-default,router-default,router,master,FALSE
 Ingress,TCP,443,openshift-ingress,router-internal-default,router-default,router,master,FALSE
 Ingress,TCP,1936,openshift-ingress,router-internal-default,router-default,router,master,FALSE
-Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
-Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE


### PR DESCRIPTION
Ports 10258 and 10260 were added to the commatrix as a results of missmatching the bm sno cluster to the right platform type. This PR updates th bm sno commatrix to match a sno none type cluster exactly.