### PR TITLE
[release-4.18] Update test validates the commatrix in OCP docs is up-to-date

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,9 +22,8 @@ var (
 	cs           *client.ClientSet
 	commatrix    *types.ComMatrix
 	isSNO        bool
-	isBM         bool
-	deployment   types.Deployment
 	platformType configv1.PlatformType
+	deployment   types.Deployment
 	utilsHelpers utils.UtilsInterface
 	epExporter   *endpointslices.EndpointSlicesExporter
 	nodeList     *corev1.NodeList
@@ -63,15 +62,8 @@ var _ = BeforeSuite(func() {
 		deployment = types.SNO
 	}
 
-	platformType, err := utilsHelpers.GetPlatformType()
+	platformType, err = utilsHelpers.GetPlatformType()
 	Expect(err).NotTo(HaveOccurred())
-
-	isBM = false
-	// Assuming Telco partners use 'None' platform type just on Bare Metal.
-	// Mark as Bare Metal if the platform type is either 'BareMetal' (multi-node BM) or 'None' (SNO BM).
-	if platformType == configv1.BareMetalPlatformType || platformType == configv1.NonePlatformType {
-		isBM = true
-	}
 
 	epExporter, err = endpointslices.New(cs)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The current test is based on the old commatrix docs format the included only one matrix. Hence, we exclude static entries with platform and deployment types, that differ from the ones the cluster the test is running on has, from the documented commatrix when comparing it to the generated one. The new version (4.18 and above) contains matrices by platform type and deployment, and each cluster is compared to the corresponding matrix. As a results, the exclusion of the static entries by deployment and platform types from the documented commatrix is not needed.

This PR was manually cherry picked from [PR#127](https://github.com/openshift-kni/commatrix/pull/127), as there were merge conflicts.