### PR TITLE
add missing port on bm 9454 to static entries and bm documentation

### DIFF
--- a/docs/stable/raw/bm.csv
+++ b/docs/stable/raw/bm.csv
@@ -24,6 +24,7 @@ Ingress,TCP,9192,openshift-cluster-machine-approver,machine-approver,machine-app
 Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cluster-cloud-controller-manager,cluster-cloud-controller-manager,master,FALSE
 Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
+Ingress,TCP,9454,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
 Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
 Ingress,TCP,9979,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE

--- a/docs/stable/unique/bm.csv
+++ b/docs/stable/unique/bm.csv
@@ -6,6 +6,7 @@ Ingress,TCP,6385,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,F
 Ingress,TCP,6388,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
+Ingress,TCP,9454,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,18080,openshift-kni-infra,,coredns,coredns,master,FALSE
 Ingress,UDP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
 Ingress,UDP,6081,openshift-ovn-kubernetes,ovn-kubernetes geneve,,,master,FALSE

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -326,6 +326,16 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
+		Port:      9454,
+		NodeRole:  "master",
+		Service:   "",
+		Namespace: "openshift-kni-infra",
+		Pod:       "haproxy",
+		Container: "haproxy",
+		Optional:  false,
+	}, {
+		Direction: "Ingress",
+		Protocol:  "TCP",
 		Port:      6385,
 		NodeRole:  "master",
 		Service:   "",


### PR DESCRIPTION
port are expose but dont have endpointslice from 4.19+ need to add it to the static entry list