### PR TITLE
Improve supported cluster's platform type check

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -206,6 +206,10 @@ func Run(o *GenerateOptions) (err error) {
 		return fmt.Errorf("failed to get platform type %s", err)
 	}
 
+	if !slices.Contains(types.SupportedPlatforms, platformType) {
+		return fmt.Errorf("unsupported platform type: %s. Supported platform types are: %v", platformType, types.SupportedPlatforms)
+	}
+
 	matrix, err := generateMatrix(o, deployment, platformType)
 	if err != nil {
 		return fmt.Errorf("failed to generate endpoint slice matrix: %v", err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,12 +13,20 @@ import (
 
 	"github.com/gocarina/gocsv"
 
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
+
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift-kni/commatrix/pkg/consts"
 	"github.com/openshift-kni/commatrix/pkg/utils"
 )
+
+var SupportedPlatforms = []configv1.PlatformType{
+	configv1.AWSPlatformType,
+	configv1.BareMetalPlatformType,
+	configv1.NonePlatformType,
+}
 
 type Deployment int
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"slices"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -45,12 +44,6 @@ const (
 	interval = 1 * time.Second
 	timeout  = 10 * time.Minute
 )
-
-var SupportedPlatforms = []configv1.PlatformType{
-	configv1.AWSPlatformType,
-	configv1.BareMetalPlatformType,
-	configv1.NonePlatformType,
-}
 
 func New(c *client.ClientSet) UtilsInterface {
 	return &utils{c}
@@ -262,12 +255,7 @@ func (u *utils) GetPlatformType() (configv1.PlatformType, error) {
 		return "", err
 	}
 
-	platformType := infra.Status.PlatformStatus.Type
-	if !slices.Contains(SupportedPlatforms, platformType) {
-		return "", fmt.Errorf("unsupported platform type: %s. Supported platform types are: %v", platformType, SupportedPlatforms)
-	}
-
-	return platformType, nil
+	return infra.Status.PlatformStatus.Type, nil
 }
 
 func (u *utils) GetPodLogs(namespace string, pod *corev1.Pod) (string, error) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,14 +1,17 @@
 package e2e
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/commatrix/pkg/client"
+	"github.com/openshift-kni/commatrix/pkg/types"
 	"github.com/openshift-kni/commatrix/pkg/utils"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,6 +54,11 @@ var _ = BeforeSuite(func() {
 
 	platformType, err = utilsHelpers.GetPlatformType()
 	Expect(err).NotTo(HaveOccurred())
+
+	// if cluster's type is not supported by the commatrix app, skip tests
+	if !slices.Contains(types.SupportedPlatforms, platformType) {
+		Skip(fmt.Sprintf("unsupported platform type: %s. Supported platform types are: %v", platformType, types.SupportedPlatforms))
+	}
 })
 
 func TestE2e(t *testing.T) {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -66,10 +66,15 @@ var _ = Describe("Validation", func() {
 
 	It("generated communication matrix should be equal to documented communication matrix", func() {
 		By("generate documented commatrix file path")
-		docType := "aws"
-		if platformType == configv1.BareMetalPlatformType {
+
+		// clusters with unsupported platform types had skip the test, so we assume the platform type is supported
+		var docType string
+		switch platformType {
+		case configv1.AWSPlatformType:
+			docType = "aws"
+		case configv1.BareMetalPlatformType:
 			docType = "bm"
-		} else if platformType == configv1.NonePlatformType {
+		case configv1.NonePlatformType:
 			docType = "none"
 		}
 


### PR DESCRIPTION
Instead of checking if the cluster's platform type is supported within the `GetPlatformType` function, we will check and handle the platform type out side of the function to avoid the assumption the function is always called in order to get the platform type.

Also if cluster's platform type is not supported, the e2e tests will be
skipped.