### PR TITLE
[release-4.17] Remove port 9537 from static entries

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -71,16 +71,6 @@ var GeneralStaticEntriesWorker = []ComDetails{
 		Pod:       "ovnkube",
 		Container: "ovnkube-controller",
 		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      9537,
-		NodeRole:  "worker",
-		Service:   "crio-metrics",
-		Namespace: "Host system service",
-		Pod:       "",
-		Container: "",
-		Optional:  false,
 	},
 }
 
@@ -114,16 +104,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 		Namespace: "openshift-ovn-kubernetes",
 		Pod:       "ovnkube",
 		Container: "ovnkube-controller",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      9537,
-		NodeRole:  "master",
-		Service:   "crio-metrics",
-		Namespace: "Host system service",
-		Pod:       "",
-		Container: "",
 		Optional:  false,
 	}, {
 		Direction: "Ingress",


### PR DESCRIPTION
Port 9537 is not exposed and hence was removed from documented commatrix (see [PR#93895](https://github.com/openshift/openshift-docs/pull/93895)). Therefore, it should be removed from static entries as well.