### PR TITLE
[release-4.18] Duplicate bm-sno commatrix under the name none-sno

### DIFF
--- a/docs/stable/raw/none-sno.csv
+++ b/docs/stable/raw/none-sno.csv
@@ -1,0 +1,35 @@
+Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
+Ingress,TCP,22,Host system service,sshd,,,master,TRUE
+Ingress,TCP,80,openshift-ingress,router-internal-default,router-default,router,master,FALSE
+Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
+Ingress,TCP,443,openshift-ingress,router-internal-default,router-default,router,master,FALSE
+Ingress,TCP,1936,openshift-ingress,router-internal-default,router-default,router,master,FALSE
+Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
+Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
+Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
+Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
+Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
+Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
+Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
+Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
+Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE
+Ingress,TCP,9105,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-ovn-metrics,master,FALSE
+Ingress,TCP,9107,openshift-ovn-kubernetes,egressip-node-healthcheck,ovnkube-node,ovnkube-controller,master,FALSE
+Ingress,TCP,9108,openshift-ovn-kubernetes,ovn-kubernetes-control-plane,ovnkube-control-plane,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9192,openshift-cluster-machine-approver,machine-approver,machine-approver,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cluster-cloud-controller-manager,cluster-cloud-controller-manager,master,FALSE
+Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
+Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
+Ingress,TCP,9979,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
+Ingress,TCP,9980,openshift-etcd,etcd,etcd,etcd,master,FALSE
+Ingress,TCP,10250,Host system service,kubelet,,,master,FALSE
+Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,master,FALSE
+Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube-controller-manager,kube-controller-manager,master,FALSE
+Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
+Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
+Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
+Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
+Ingress,TCP,22624,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
+Ingress,UDP,111,Host system service,rpcbind,,,master,TRUE

--- a/docs/stable/unique/none-sno.csv
+++ b/docs/stable/unique/none-sno.csv
@@ -1,0 +1,4 @@
+Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
+Ingress,TCP,80,openshift-ingress,router-internal-default,router-default,router,master,FALSE
+Ingress,TCP,443,openshift-ingress,router-internal-default,router-default,router,master,FALSE
+Ingress,TCP,1936,openshift-ingress,router-internal-default,router-default,router,master,FALSE

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -35,11 +35,13 @@ var _ = Describe("Validation", func() {
 	It("generated communication matrix should be equal to documented communication matrix", func() {
 		By("generate documented commatrix file path")
 		docType := "aws"
-		// Mark as Bare Metal if the platform type is either 'BareMetal' (multi-node BM) or 'None' (SNO BM).
-		// Assuming Telco partners use 'None' platform type just on Bare Metal.
-		if platformType == configv1.BareMetalPlatformType || platformType == configv1.NonePlatformType {
+		if platformType == configv1.BareMetalPlatformType {
 			docType = "bm"
+		} else if platformType == configv1.NonePlatformType {
+			docType = "none"
 		}
+
+		// Asuming telco partenrs are using only none type and aws platform types for sno clusters.
 		if isSNO {
 			docType += "-sno"
 		}


### PR DESCRIPTION
This PR is the first of changing the bm-sno commmatrix name to none-sno. after this PR will be merged, the pointer to the commatrix in the official documentation will be changed, and than we can remove the commatrix under the name bm-sno.

This PR was manully cherry picked from [PR#139](https://github.com/openshift-kni/commatrix/pull/139)