### PR TITLE
Create a Dockerfile that builds commatrix binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/4.20:oc-rpms AS oc
+# Final image temporarly contains golang, will be removed after the e2e tests removed from our repo
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20
+
+WORKDIR /go/src/github.com/openshift-kni/commatrix
+RUN chmod -R a+w /go/src/github.com/openshift-kni/commatrix
+
+COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+# Build the commatrix binary
+RUN go mod vendor && \
+    make build && \
+    make install INSTALL_DIR=/usr/bin/


### PR DESCRIPTION
This PR creates a Dockerfile that builds the commatrix binary in order to use the commatrix plugin in the origin tests. After the merge of this PR we will add a prow configuration in the release repo in order to build the image and promote it using the ci operator, and than use the build image as a base image for building the origin's repo podman that runs the origin tests (see [dockerfile](https://github.com/openshift/origin/blob/main/images/tests/Dockerfile.rhel)) so the it will contain the necessary plugin.