### PR TITLE
Remove openshift cloud controller manager static entries

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -142,8 +142,7 @@ var (
 )
 
 func TestCommatrixGeneration(t *testing.T) {
-	expectedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster,
-		types.GeneralStaticEntriesMaster, types.GeneralStaticEntriesWorker, types.StandardStaticEntries)
+	expectedComDetails := slices.Concat(testEpsComDetails, types.GeneralStaticEntriesMaster, types.GeneralStaticEntriesWorker, types.StandardStaticEntries)
 
 	expectedComMatrix := types.ComMatrix{Matrix: expectedComDetails}
 	expectedComMatrix.SortAndRemoveDuplicates()

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -116,8 +116,7 @@ func (cm *CommunicationMatrixCreator) GetStaticEntries() ([]types.ComDetails, er
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
 	case configv1.AWSPlatformType:
-		log.Debug("Adding Cloud static entries")
-		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
+		log.Debug("There are no Cloud static entries to be added")
 	case configv1.NonePlatformType:
 		break
 	default:

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -230,35 +230,6 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(gotComDetails).To(o.Equal(wantedComDetails))
 		})
 
-		g.It("Should successfully get static entries suitable to cloud standard cluster", func() {
-			g.By("Creating new communication matrix suitable to cloud standard cluster")
-			cm, err := New(nil, "", "", configv1.AWSPlatformType, types.Standard)
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.GetStaticEntries()
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Comparing gotten static entries to wanted comDetails")
-			wantedComDetails := slices.Concat(types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster,
-				types.StandardStaticEntries, types.GeneralStaticEntriesWorker)
-			o.Expect(gotComDetails).To(o.Equal(wantedComDetails))
-		})
-
-		g.It("Should successfully get static entries suitable to cloud SNO cluster", func() {
-			g.By("Creating new communication matrix suitable to cloud SNO cluster")
-			cm, err := New(nil, "", "", configv1.AWSPlatformType, types.SNO)
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.GetStaticEntries()
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Comparing gotten static entries to wanted comDetails")
-			wantedComDetails := slices.Concat(types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster)
-			o.Expect(gotComDetails).To(o.Equal(wantedComDetails))
-		})
-
 		g.It("Should return an error due to an invalid value for cluster environment", func() {
 			g.By("Creating new communication matrix with an invalid value for cluster environment")
 			cm, err := New(nil, "", "", "invalid", types.SNO)
@@ -303,7 +274,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Generating wanted comDetails based on cluster features")
-			wantedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster)
+			wantedComDetails := slices.Concat(testEpsComDetails, types.GeneralStaticEntriesMaster)
 
 			g.By("Add to wanted comDetails the example static entries")
 			wantedComDetails = slices.Concat(wantedComDetails, exampleComDetailsList)
@@ -327,7 +298,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Generating wanted comDetails")
-			wantedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster)
+			wantedComDetails := slices.Concat(testEpsComDetails, types.GeneralStaticEntriesMaster)
 			wantedComMatrix := types.ComMatrix{Matrix: wantedComDetails}
 			wantedComMatrix.SortAndRemoveDuplicates()
 

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -158,16 +158,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      9258,
-		NodeRole:  "master",
-		Service:   "machine-approver",
-		Namespace: "openshift-cloud-controller-manager-operator",
-		Pod:       "cluster-cloud-controller-manager",
-		Container: "cluster-cloud-controller-manager",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      22624,
 		NodeRole:  "master",
 		Service:   "machine-config-server",
@@ -292,20 +282,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 		Namespace: "openshift-kni-infra",
 		Pod:       "coredns",
 		Container: "coredns",
-		Optional:  false,
-	},
-}
-
-var CloudStaticEntriesMaster = []ComDetails{
-	{
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10258,
-		NodeRole:  "master",
-		Service:   "cloud-controller",
-		Namespace: "openshift-cloud-controller-manager-operator",
-		Pod:       "cloud-controller-manager",
-		Container: "cloud-controller-manager",
 		Optional:  false,
 	},
 }


### PR DESCRIPTION
Service was added to port 10258 (see [PR](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/399)), and the selector of the service of 9258 was updated to match its pod (see [PR](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/398)). Hence, they can be removed from static entries. 
Also, as there are no more cloud static entries the unit test case which checks the ability to get cloud static entries is not needed any more and was removed.