### PR TITLE
add new static entries for ipv6

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -210,7 +210,12 @@ func Run(o *GenerateOptions) (err error) {
 		return fmt.Errorf("unsupported platform type: %s. Supported platform types are: %v", platformType, types.SupportedPlatforms)
 	}
 
-	matrix, err := generateMatrix(o, deployment, platformType)
+	ipv6Enabled, err := o.utilsHelpers.IsIPv6Enabled()
+	if err != nil {
+		return fmt.Errorf("failed to detect IPv6: %v", err)
+	}
+
+	matrix, err := generateMatrix(o, deployment, platformType, ipv6Enabled)
 	if err != nil {
 		return fmt.Errorf("failed to generate endpoint slice matrix: %v", err)
 	}
@@ -239,7 +244,7 @@ func Run(o *GenerateOptions) (err error) {
 	return nil
 }
 
-func generateMatrix(o *GenerateOptions, deployment types.Deployment, platformType configv1.PlatformType) (*types.ComMatrix, error) {
+func generateMatrix(o *GenerateOptions, deployment types.Deployment, platformType configv1.PlatformType, ipv6Enabled bool) (*types.ComMatrix, error) {
 	if o.debug {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -250,7 +255,7 @@ func generateMatrix(o *GenerateOptions, deployment types.Deployment, platformTyp
 	}
 
 	log.Debug("Creating communication matrix")
-	commMatrix, err := commatrixcreator.New(epExporter, o.customEntriesPath, o.customEntriesFormat, platformType, deployment)
+	commMatrix, err := commatrixcreator.New(epExporter, o.customEntriesPath, o.customEntriesFormat, platformType, deployment, ipv6Enabled)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -41,6 +41,15 @@ var (
 		},
 	}
 
+	network = &configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.NetworkSpec{
+			ClusterNetwork: []configv1.ClusterNetworkEntry{{CIDR: "10.0.0.0/16"}},
+		},
+	}
+
 	testNode = &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
@@ -216,7 +225,7 @@ func TestCommatrixGeneration(t *testing.T) {
 	err = configv1.AddToScheme(sch)
 	require.NoError(t, err)
 
-	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(infra, testNode, testPod, testService, testEndpointSlice).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(infra, network, testNode, testPod, testService, testEndpointSlice).Build()
 	fakeClientset := fakek.NewSimpleClientset()
 
 	clientset := &client.ClientSet{

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/openshift/library-go v0.0.0-20250602082827-408fc1e33d77 // indirect
+	github.com/openshift/library-go v0.0.0-20250602082827-408fc1e33d77
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -19,15 +19,17 @@ type CommunicationMatrixCreator struct {
 	customEntriesFormat string
 	platformType        configv1.PlatformType
 	deployment          types.Deployment
+	ipv6Enabled         bool
 }
 
-func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, deployment types.Deployment) (*CommunicationMatrixCreator, error) {
+func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, deployment types.Deployment, ipv6Enabled bool) (*CommunicationMatrixCreator, error) {
 	return &CommunicationMatrixCreator{
 		exporter:            exporter,
 		customEntriesPath:   customEntriesPath,
 		customEntriesFormat: customEntriesFormat,
 		platformType:        platformType,
 		deployment:          deployment,
+		ipv6Enabled:         ipv6Enabled,
 	}, nil
 }
 
@@ -126,12 +128,18 @@ func (cm *CommunicationMatrixCreator) GetStaticEntries() ([]types.ComDetails, er
 
 	log.Debug("Adding general static entries")
 	comDetails = append(comDetails, types.GeneralStaticEntriesMaster...)
+	if cm.ipv6Enabled {
+		comDetails = append(comDetails, types.GeneralIPv6StaticEntriesMaster...)
+	}
 	if cm.deployment == types.SNO {
 		return comDetails, nil
 	}
 
 	comDetails = append(comDetails, types.StandardStaticEntries...)
 	comDetails = append(comDetails, types.GeneralStaticEntriesWorker...)
+	if cm.ipv6Enabled {
+		comDetails = append(comDetails, types.GeneralIPv6StaticEntriesWorker...)
+	}
 	log.Debug("Successfully determined static entries")
 	return comDetails, nil
 }

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -309,3 +309,32 @@ var StandardStaticEntries = []ComDetails{
 		Optional:  false,
 	},
 }
+
+// General IPv6-only static entries that should be applied when the cluster supports IPv6.
+var GeneralIPv6StaticEntriesWorker = []ComDetails{
+	{
+		Direction: "Ingress",
+		Protocol:  "UDP",
+		Port:      546,
+		NodeRole:  "worker",
+		Service:   "NetworkManager",
+		Namespace: "",
+		Pod:       "",
+		Container: "",
+		Optional:  false,
+	},
+}
+
+var GeneralIPv6StaticEntriesMaster = []ComDetails{
+	{
+		Direction: "Ingress",
+		Protocol:  "UDP",
+		Port:      546,
+		NodeRole:  "master",
+		Service:   "NetworkManager",
+		Namespace: "",
+		Pod:       "",
+		Container: "",
+		Optional:  false,
+	},
+}

--- a/pkg/utils/mock/mock_utils.go
+++ b/pkg/utils/mock/mock_utils.go
@@ -122,6 +122,21 @@ func (mr *MockUtilsInterfaceMockRecorder) GetPodLogs(namespace, pod interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodLogs", reflect.TypeOf((*MockUtilsInterface)(nil).GetPodLogs), namespace, pod)
 }
 
+// IsIPv6Enabled mocks base method.
+func (m *MockUtilsInterface) IsIPv6Enabled() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsIPv6Enabled")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsIPv6Enabled indicates an expected call of IsIPv6Enabled.
+func (mr *MockUtilsInterfaceMockRecorder) IsIPv6Enabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIPv6Enabled", reflect.TypeOf((*MockUtilsInterface)(nil).IsIPv6Enabled))
+}
+
 // IsSNOCluster mocks base method.
 func (m *MockUtilsInterface) IsSNOCluster() (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
add new static entries for ipv6:
need to add this to the list:     
     Ingress,UDP,546,,NetworkManager,,,master,false
    Ingress,UDP,546,,NetworkManager,,,worker,false
    they are required on ipv6 clusters