### PR TITLE
[release-4.17] Remove machine api webhook port from static entries

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -313,16 +313,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 		Pod:       "coredns",
 		Container: "coredns",
 		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      9447,
-		NodeRole:  "master",
-		Service:   "",
-		Namespace: "openshift-machine-api",
-		Pod:       "metal3-baremetal-operator",
-		Container: "",
-		Optional:  false,
 	},
 }
 


### PR DESCRIPTION
As it was decided that the webhook port (9447) should not be exposed to the host (see [PR](https://github.com/openshift/cluster-baremetal-operator/pull/505)), it should be removed from the official doc and the static entries.
After the merge of this PR a PR will be opened in the openshift docs repo to remove the port from the official doc.