### PR TITLE
Revert "[release-4.20] adding logs to invistigate the failure of empty noderole"

### DIFF
--- a/pkg/endpointslices/endpointslices.go
+++ b/pkg/endpointslices/endpointslices.go
@@ -2,7 +2,6 @@ package endpointslices
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -52,8 +51,6 @@ func New(cs *client.ClientSet) (*EndpointSlicesExporter, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Info-level log to trace node to role mapping during initialization
-		log.Infof("node role mapping: node=%s role=%s", node.Name, nodeToRole[node.Name])
 	}
 
 	return &EndpointSlicesExporter{cs, nodeToRole, []EndpointSlicesInfo{}}, nil
@@ -161,28 +158,8 @@ func createEPSliceInfo(service corev1.Service, ep discoveryv1.EndpointSlice, pod
 func (ei *EndpointSlicesInfo) getEndpointSliceNodeRoles(nodesRoles map[string]string) []string {
 	// map to prevent duplications
 	rolesMap := make(map[string]bool)
-	// Dump the full node->role map for troubleshooting empty roles
-	log.Infof("node->role map entries=%d content=%v", len(nodesRoles), nodesRoles)
 	for _, endpoint := range ei.EndpointSlice.Endpoints {
-		var nodeName string
-		if endpoint.NodeName == nil {
-			log.Warningf("EndpointSlice %s/%s: endpoint has nil NodeName; service=%s", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, ei.Service.Name)
-			if dump, err := json.MarshalIndent(ei.EndpointSlice, "", "  "); err == nil {
-				log.Infof("EndpointSlice dump %s/%s:\n%s", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, string(dump))
-			} else {
-				log.Warningf("failed to marshal EndpointSlice %s/%s: %v", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, err)
-			}
-			nodeName = ""
-		} else {
-			nodeName = *endpoint.NodeName
-		}
-		role, ok := nodesRoles[nodeName]
-		if !ok {
-			log.Warningf("EndpointSlice %s/%s: node %s not found in node->role map; service=%s", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, nodeName, ei.Service.Name)
-		}
-		if role == "" {
-			log.Warningf("EndpointSlice %s/%s: empty role for node %s; service=%s", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, nodeName, ei.Service.Name)
-		}
+		role := nodesRoles[*endpoint.NodeName]
 		rolesMap[role] = true
 	}
 
@@ -201,13 +178,6 @@ func (ei *EndpointSlicesInfo) toComDetails(nodesRoles map[string]string) ([]type
 
 	res := make([]types.ComDetails, 0)
 
-	// Dump the entire EndpointSlice for visibility
-	if dump, err := json.MarshalIndent(ei.EndpointSlice, "", "  "); err == nil {
-		log.Infof("EndpointSlice full dump %s/%s:\n%s", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, string(dump))
-	} else {
-		log.Warningf("failed to marshal EndpointSlice %s/%s: %v", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, err)
-	}
-
 	// Get the Namespace and Pod's name from the service.
 	namespace := ei.Service.Namespace
 	name, err := extractControllerName(&ei.Pods[0])
@@ -217,9 +187,6 @@ func (ei *EndpointSlicesInfo) toComDetails(nodesRoles map[string]string) ([]type
 
 	// Get the node roles of this endpointslice.
 	roles := ei.getEndpointSliceNodeRoles(nodesRoles)
-	if len(roles) == 0 {
-		log.Warningf("EndpointSlice %s/%s: no node roles resolved; service=%s", ei.EndpointSlice.Namespace, ei.EndpointSlice.Name, ei.Service.Name)
-	}
 
 	epSlice := ei.EndpointSlice
 	optional := isOptional(epSlice)
@@ -232,9 +199,6 @@ func (ei *EndpointSlicesInfo) toComDetails(nodesRoles map[string]string) ([]type
 		}
 
 		for _, role := range roles {
-			if role == "" {
-				log.Warningf("EndpointSlice %s/%s: creating ComDetails with empty node role; service=%s port=%d protocol=%s pod=%s", namespace, ei.EndpointSlice.Name, ei.Service.Name, int(*port.Port), string(*port.Protocol), name)
-			}
 			res = append(res, types.ComDetails{
 				Direction: consts.IngressLabel,
 				Protocol:  string(*port.Protocol),


### PR DESCRIPTION
Reverts openshift-kni/commatrix#183