### PR TITLE
Remove port 6385 from static entries

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -266,16 +266,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      6385,
-		NodeRole:  "master",
-		Service:   "",
-		Namespace: "openshift-machine-api",
-		Pod:       "ironic-proxy",
-		Container: "ironic-proxy",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      18080,
 		NodeRole:  "master",
 		Service:   "",


### PR DESCRIPTION
Port 6385 is an exposed port that was missing a service for that was included in the satic entries list. Now, a service was added to that port (see [PR](https://github.com/openshift/cluster-baremetal-operator/pull/510)), and hence can be removed from the static entries list.