### PR TITLE
[release-4.18] Remove openshift cloud controller manager static entries

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -158,16 +158,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      9258,
-		NodeRole:  "master",
-		Service:   "machine-approver",
-		Namespace: "openshift-cloud-controller-manager-operator",
-		Pod:       "cluster-cloud-controller-manager",
-		Container: "cluster-cloud-controller-manager",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      10357,
 		NodeRole:  "master",
 		Service:   "openshift-kube-apiserver-healthz",
@@ -342,26 +332,6 @@ var CloudStaticEntriesWorker = []ComDetails{
 
 var CloudStaticEntriesMaster = []ComDetails{
 	{
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10260,
-		NodeRole:  "master",
-		Service:   "cloud-controller",
-		Namespace: "openshift-cloud-controller-manager-operator",
-		Pod:       "cloud-controller-manager",
-		Container: "cloud-controller-manager",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10258,
-		NodeRole:  "master",
-		Service:   "cloud-controller",
-		Namespace: "openshift-cloud-controller-manager-operator",
-		Pod:       "cloud-controller-manager",
-		Container: "cloud-controller-manager",
-		Optional:  false,
-	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
 		Port:      10300,


### PR DESCRIPTION
This PR is a manual cherry pick of [PR#177](https://github.com/openshift-kni/commatrix/pull/177) due to conflicts.

Service was added to port 10258 and 10260 (see https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/405), and the selector of the service of 9258 was updated to match its pod (see https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/403). Hence, they can be removed from static entries.