### PR TITLE
[release-4.18]: remove port 10357 as it set as a local port and no need to expose

### DIFF
--- a/docs/stable/raw/aws-sno.csv
+++ b/docs/stable/raw/aws-sno.csv
@@ -31,7 +31,6 @@ Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,ku
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
 Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
-Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
 Ingress,TCP,22624,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/raw/aws.csv
+++ b/docs/stable/raw/aws.csv
@@ -29,7 +29,6 @@ Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,ku
 Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
 Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
-Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
 Ingress,TCP,22624,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/raw/bm.csv
+++ b/docs/stable/raw/bm.csv
@@ -32,7 +32,6 @@ Ingress,TCP,10250,Host system service,kubelet,,,master,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,master,FALSE
 Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube-controller-manager,kube-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
-Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,18080,openshift-kni-infra,,coredns,coredns,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/raw/none-sno.csv
+++ b/docs/stable/raw/none-sno.csv
@@ -28,7 +28,6 @@ Ingress,TCP,10250,Host system service,kubelet,,,master,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,master,FALSE
 Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube-controller-manager,kube-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
-Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
 Ingress,TCP,22624,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/docs/stable/unique/common-master.csv
+++ b/docs/stable/unique/common-master.csv
@@ -25,7 +25,6 @@ Ingress,TCP,10250,Host system service,kubelet,,,master,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,master,FALSE
 Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube-controller-manager,kube-controller-manager,master,FALSE
 Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
-Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
 Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
 Ingress,TCP,22624,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -158,16 +158,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      10357,
-		NodeRole:  "master",
-		Service:   "openshift-kube-apiserver-healthz",
-		Namespace: "openshift-kube-apiserver",
-		Pod:       "kube-apiserver",
-		Container: "kube-apiserver-check-endpoints",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      22624,
 		NodeRole:  "master",
 		Service:   "machine-config-server",


### PR DESCRIPTION
This is a manual cherry pick of [PR#185](https://github.com/openshift-kni/commatrix/pull/185), as automatic cherry pick encoutered merge conflicts.