### PR TITLE
[release-4.17]: remove port 10357 as it set as a local port and no need to expose

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -158,16 +158,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      10357,
-		NodeRole:  "master",
-		Service:   "openshift-kube-apiserver-healthz",
-		Namespace: "openshift-kube-apiserver",
-		Pod:       "kube-apiserver",
-		Container: "kube-apiserver-check-endpoints",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      17697,
 		NodeRole:  "master",
 		Service:   "openshift-kube-apiserver-healthz",


### PR DESCRIPTION
This is a manual cherry pick of [PR#202](https://github.com/openshift-kni/commatrix/pull/202), as automatic cherry pick encoutered merge conflicts. After the merge of this PR, port 10357 will be removed from the 4.17 documented commatrix in the openshift-docs repo.

(cherry picked from commit 87d576b8656d4c35b7b8342afd7bae11570d855b)