### PR TITLE
[release-4.17] Remove port 10300 and 10390 from doc commatrix and static entries

### DIFF
--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -137,12 +137,7 @@ func (cm *CommunicationMatrixCreator) getStaticEntries() ([]types.ComDetails, er
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
 	case types.Cloud:
-		log.Debug("Adding Cloud static entries")
-		comDetails = append(comDetails, types.CloudStaticEntriesMaster...)
-		if cm.d == types.SNO {
-			break
-		}
-		comDetails = append(comDetails, types.CloudStaticEntriesWorker...)
+		log.Debug("There are no Cloud static entries to be added")
 	default:
 		log.Errorf("Invalid value for cluster environment: %v", cm.e)
 		return nil, fmt.Errorf("invalid value for cluster environment")

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -239,22 +239,8 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Comparing gotten static entries to wanted comDetails")
-			wantedComDetails := slices.Concat(types.CloudStaticEntriesMaster, types.CloudStaticEntriesWorker,
-				types.GeneralStaticEntriesMaster, types.StandardStaticEntries, types.GeneralStaticEntriesWorker)
-			o.Expect(gotComDetails).To(o.Equal(wantedComDetails))
-		})
-
-		g.It("Should successfully get static entries suitable to cloud SNO cluster", func() {
-			g.By("Creating new communication matrix suitable to cloud SNO cluster")
-			cm, err := New(nil, "", "", types.Cloud, types.SNO)
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Getting static entries comDetails of the created communication matrix")
-			gotComDetails, err := cm.getStaticEntries()
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Comparing gotten static entries to wanted comDetails")
-			wantedComDetails := slices.Concat(types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster)
+			wantedComDetails := slices.Concat(types.GeneralStaticEntriesMaster,
+				types.StandardStaticEntries, types.GeneralStaticEntriesWorker)
 			o.Expect(gotComDetails).To(o.Equal(wantedComDetails))
 		})
 
@@ -302,7 +288,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Generating wanted comDetails based on cluster features")
-			wantedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster)
+			wantedComDetails := slices.Concat(testEpsComDetails, types.GeneralStaticEntriesMaster)
 
 			g.By("Add to wanted comDetails the example static entries")
 			wantedComDetails = slices.Concat(wantedComDetails, exampleComDetailsList)
@@ -326,7 +312,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Generating wanted comDetails")
-			wantedComDetails := slices.Concat(testEpsComDetails, types.CloudStaticEntriesMaster, types.GeneralStaticEntriesMaster)
+			wantedComDetails := slices.Concat(testEpsComDetails, types.GeneralStaticEntriesMaster)
 			wantedComMatrix := types.ComMatrix{Matrix: wantedComDetails}
 			wantedComMatrix.SortAndRemoveDuplicates()
 

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -266,54 +266,6 @@ var BaremetalStaticEntriesMaster = []ComDetails{
 	},
 }
 
-var CloudStaticEntriesWorker = []ComDetails{
-	{
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10300,
-		NodeRole:  "worker",
-		Service:   "csi-livenessprobe",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-driver",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10309,
-		NodeRole:  "worker",
-		Service:   "csi-node-driver",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-node-driver-registrar",
-		Optional:  false,
-	},
-}
-
-var CloudStaticEntriesMaster = []ComDetails{
-	{
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10300,
-		NodeRole:  "master",
-		Service:   "csi-livenessprobe",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-driver",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      10309,
-		NodeRole:  "master",
-		Service:   "csi-node-driver",
-		Namespace: "openshift-cluster-csi-drivers",
-		Pod:       "csi-driver-node",
-		Container: "csi-node-driver-registrar",
-		Optional:  false,
-	},
-}
-
 var StandardStaticEntries = []ComDetails{
 	{
 		Direction: "Ingress",

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -117,10 +117,7 @@ var _ = Describe("Validation", func() {
 
 		// if cluster is running on BM exclude Cloud static entries in diff generation
 		// else cluster is running on Cloud and exclude BM static entries in diff generation.
-		if isBM {
-			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.CloudStaticEntriesWorker}, "worker")
-			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.CloudStaticEntriesMaster}, "master")
-		} else {
+		if !isBM {
 			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.BaremetalStaticEntriesWorker}, "worker")
 			docComDetailsList = excludeStaticEntriesWithGivenNodeRole(docComDetailsList, &types.ComMatrix{Matrix: types.BaremetalStaticEntriesMaster}, "master")
 		}


### PR DESCRIPTION
Ports 10300, 10390 had been changed to be used only internally and there for shouldn't be documented in the communication matrix. Note: types.CloudStaticEntriesWorker was deleted as it only contained the above ports.

(cherry picked from commit ea4bdcc536898f31f6ed832add1ba7790e78f813)