### PR TITLE
Remove unnecessary generate pkg's unit tests

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -195,24 +195,6 @@ func TestCommatrixGeneration(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "Should generate CSV output",
-			args: []string{"generate", "--format", "csv", "--destDir", destDir},
-			expectedFunc: func() (string, error) {
-				expectedOutput, err := expectedComMatrix.ToCSV()
-				return string(expectedOutput), err
-			},
-			wantErr: false,
-		},
-		{
-			name: "Should generate JSON output",
-			args: []string{"generate", "--format", "json", "--destDir", destDir},
-			expectedFunc: func() (string, error) {
-				expectedOutput, err := expectedComMatrix.ToJSON()
-				return string(expectedOutput), err
-			},
-			wantErr: false,
-		},
-		{
 			name: "Should Return failure on format validation",
 			args: []string{"generate", "--format", "test"},
 			expectedFunc: func() (string, error) {


### PR DESCRIPTION
There is no need to test the output of the generate command in a unit test as we're already doing that in our e2e tests.