### PR TITLE
add SupportedTopologies for control-plane modes

### DIFF
--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -16,22 +16,22 @@ import (
 )
 
 type CommunicationMatrixCreator struct {
-	exporter            *endpointslices.EndpointSlicesExporter
-	customEntriesPath   string
-	customEntriesFormat string
-	platformType        configv1.PlatformType
-	deployment          types.Deployment
-	ipv6Enabled         bool
+	exporter             *endpointslices.EndpointSlicesExporter
+	customEntriesPath    string
+	customEntriesFormat  string
+	platformType         configv1.PlatformType
+	controlPlaneTopology configv1.TopologyMode
+	ipv6Enabled          bool
 }
 
-func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, deployment types.Deployment, ipv6Enabled bool) (*CommunicationMatrixCreator, error) {
+func New(exporter *endpointslices.EndpointSlicesExporter, customEntriesPath string, customEntriesFormat string, platformType configv1.PlatformType, controlPlaneTopology configv1.TopologyMode, ipv6Enabled bool) (*CommunicationMatrixCreator, error) {
 	return &CommunicationMatrixCreator{
-		exporter:            exporter,
-		customEntriesPath:   customEntriesPath,
-		customEntriesFormat: customEntriesFormat,
-		platformType:        platformType,
-		deployment:          deployment,
-		ipv6Enabled:         ipv6Enabled,
+		exporter:             exporter,
+		customEntriesPath:    customEntriesPath,
+		customEntriesFormat:  customEntriesFormat,
+		platformType:         platformType,
+		controlPlaneTopology: controlPlaneTopology,
+		ipv6Enabled:          ipv6Enabled,
 	}, nil
 }
 
@@ -125,7 +125,7 @@ func (cm *CommunicationMatrixCreator) GetStaticEntries() ([]types.ComDetails, er
 	case configv1.BareMetalPlatformType:
 		log.Debug("Adding Baremetal static entries")
 		comDetails = append(comDetails, types.BaremetalStaticEntriesMaster...)
-		if cm.deployment == types.SNO {
+		if cm.controlPlaneTopology == configv1.SingleReplicaTopologyMode {
 			break
 		}
 		comDetails = append(comDetails, types.BaremetalStaticEntriesWorker...)
@@ -143,7 +143,7 @@ func (cm *CommunicationMatrixCreator) GetStaticEntries() ([]types.ComDetails, er
 	if cm.ipv6Enabled {
 		comDetails = append(comDetails, types.GeneralIPv6StaticEntriesMaster...)
 	}
-	if cm.deployment == types.SNO {
+	if cm.controlPlaneTopology == configv1.SingleReplicaTopologyMode {
 		return comDetails, nil
 	}
 

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -296,7 +296,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 		for _, format := range []string{types.FormatCSV, types.FormatJSON, types.FormatYAML} {
 			g.It(fmt.Sprintf("Should successfully extract ComDetails from a %s file", format), func() {
 				g.By(fmt.Sprintf("Creating new communication matrix with %s static entries format", format))
-				cm, err := New(nil, fmt.Sprintf("../../samples/custom-entries/example-custom-entries.%s", format), format, configv1.BareMetalPlatformType, 0, false)
+				cm, err := New(nil, fmt.Sprintf("../../samples/custom-entries/example-custom-entries.%s", format), format, configv1.BareMetalPlatformType, configv1.HighlyAvailableTopologyMode, false)
 				o.Expect(err).ToNot(o.HaveOccurred())
 
 				g.By("Getting ComDetails List From File")
@@ -310,7 +310,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to non-matched customEntriesPath and customEntriesFormat types", func() {
 			g.By("Creating new communication matrix with non-matched customEntriesPath and customEntriesFormat")
-			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatJSON, configv1.BareMetalPlatformType, 0, false)
+			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatJSON, configv1.BareMetalPlatformType, configv1.HighlyAvailableTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComDetails List From File")
@@ -323,7 +323,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid customEntriesFormat", func() {
 			g.By("Creating new communication matrix with invalid customEntriesFormat")
-			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatNFT, configv1.BareMetalPlatformType, 0, false)
+			cm, err := New(nil, "../../samples/custom-entries/example-custom-entries.csv", types.FormatNFT, configv1.BareMetalPlatformType, configv1.HighlyAvailableTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComDetails List From File")
@@ -338,7 +338,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 	g.Context("Get static entries from file", func() {
 		g.It("Should successfully get static entries suitable to baremetal standard cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal standard cluster")
-			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, types.Standard, false)
+			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, configv1.HighlyAvailableTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -353,7 +353,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to baremetal SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal SNO cluster")
-			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, types.SNO, false)
+			cm, err := New(nil, "", "", configv1.BareMetalPlatformType, configv1.SingleReplicaTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -367,7 +367,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid value for cluster environment", func() {
 			g.By("Creating new communication matrix with an invalid value for cluster environment")
-			cm, err := New(nil, "", "", "invalid", types.SNO, false)
+			cm, err := New(nil, "", "", "invalid", configv1.SingleReplicaTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
@@ -405,7 +405,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix with custom entries", func() {
 			g.By("Creating new communication matrix with static entries")
-			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, configv1.AWSPlatformType, types.SNO, false)
+			commatrixCreator, err := New(endpointSlices, "../../samples/custom-entries/example-custom-entries.csv", types.FormatCSV, configv1.AWSPlatformType, configv1.SingleReplicaTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -429,7 +429,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
 			g.By("Creating new communication matrix without static entries")
-			commatrixCreator, err := New(endpointSlices, "", "", configv1.AWSPlatformType, types.SNO, false)
+			commatrixCreator, err := New(endpointSlices, "", "", configv1.AWSPlatformType, configv1.SingleReplicaTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -449,7 +449,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should include IPv6 static entries when ipv6Enabled is true on Standard", func() {
 			g.By("Creating communication matrix with ipv6Enabled=true for Standard")
-			commatrixCreator, err := New(endpointSlices, "", "", configv1.AWSPlatformType, types.Standard, true)
+			commatrixCreator, err := New(endpointSlices, "", "", configv1.AWSPlatformType, configv1.HighlyAvailableTopologyMode, true)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -496,7 +496,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Creating endpoint matrix")
-			commatrixCreator, err := New(localhostEndpointSlices, "", "", configv1.AWSPlatformType, types.SNO, false)
+			commatrixCreator, err := New(localhostEndpointSlices, "", "", configv1.AWSPlatformType, configv1.SingleReplicaTopologyMode, false)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -30,12 +31,25 @@ var SupportedPlatforms = []configv1.PlatformType{
 	configv1.NonePlatformType,
 }
 
-type Deployment int
+// supportedTopologies defines control plane topologies that commatrix supports:
+// - HighlyAvailable → multi-node control plane.
+// - SingleReplica   → SNO.
+// - External        → HyperShift (external control plane).
+var supportedTopologies = map[configv1.TopologyMode]bool{
+	configv1.HighlyAvailableTopologyMode: true,
+	configv1.SingleReplicaTopologyMode:   true,
+	configv1.ExternalTopologyMode:        true,
+}
 
-const (
-	SNO Deployment = iota
-	Standard
-)
+// IsSupportedTopology returns true if the given topology is supported by commatrix.
+func IsSupportedTopology(topology configv1.TopologyMode) bool {
+	return supportedTopologies[topology]
+}
+
+// SupportedTopologiesList returns the list of supported topologies.
+func SupportedTopologiesList() []configv1.TopologyMode {
+	return slices.Collect(maps.Keys(supportedTopologies))
+}
 
 const (
 	FormatJSON = "json"

--- a/pkg/utils/mock/mock_utils.go
+++ b/pkg/utils/mock/mock_utils.go
@@ -92,6 +92,21 @@ func (mr *MockUtilsInterfaceMockRecorder) DeletePod(pod interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockUtilsInterface)(nil).DeletePod), pod)
 }
 
+// GetControlPlaneTopology mocks base method.
+func (m *MockUtilsInterface) GetControlPlaneTopology() (v1.TopologyMode, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControlPlaneTopology")
+	ret0, _ := ret[0].(v1.TopologyMode)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControlPlaneTopology indicates an expected call of GetControlPlaneTopology.
+func (mr *MockUtilsInterfaceMockRecorder) GetControlPlaneTopology() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneTopology", reflect.TypeOf((*MockUtilsInterface)(nil).GetControlPlaneTopology))
+}
+
 // GetPlatformType mocks base method.
 func (m *MockUtilsInterface) GetPlatformType() (v1.PlatformType, error) {
 	m.ctrl.T.Helper()
@@ -135,21 +150,6 @@ func (m *MockUtilsInterface) IsIPv6Enabled() (bool, error) {
 func (mr *MockUtilsInterfaceMockRecorder) IsIPv6Enabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIPv6Enabled", reflect.TypeOf((*MockUtilsInterface)(nil).IsIPv6Enabled))
-}
-
-// IsSNOCluster mocks base method.
-func (m *MockUtilsInterface) IsSNOCluster() (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsSNOCluster")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsSNOCluster indicates an expected call of IsSNOCluster.
-func (mr *MockUtilsInterfaceMockRecorder) IsSNOCluster() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSNOCluster", reflect.TypeOf((*MockUtilsInterface)(nil).IsSNOCluster))
 }
 
 // RunCommandOnPod mocks base method.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -33,7 +33,7 @@ type UtilsInterface interface {
 	GetPodLogs(namespace string, pod *corev1.Pod) (string, error)
 	WriteFile(path string, data []byte) error
 	GetPlatformType() (configv1.PlatformType, error)
-	IsSNOCluster() (bool, error)
+	GetControlPlaneTopology() (configv1.TopologyMode, error)
 	WaitForPodStatus(namespace string, pod *corev1.Pod, PodPhase corev1.PodPhase) error
 	IsIPv6Enabled() (bool, error)
 }
@@ -278,18 +278,7 @@ func getNamespaceDefinition(namespace string) *corev1.Namespace {
 	}
 }
 
-func (u *utils) IsSNOCluster() (bool, error) {
-	infra := &configv1.Infrastructure{}
-	err := u.Get(context.Background(), clientOptions.ObjectKey{Name: "cluster"}, infra)
-	if err != nil {
-		return false, err
-	}
-
-	return infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, nil
-}
-
 // GetPlatformType returns the cluster's platform type.
-// If it's not AWS, BareMetal, or None, it returns an unsupported platform error.
 func (u *utils) GetPlatformType() (configv1.PlatformType, error) {
 	infra := &configv1.Infrastructure{}
 	err := u.Get(context.Background(), clientOptions.ObjectKey{Name: "cluster"}, infra)
@@ -298,6 +287,16 @@ func (u *utils) GetPlatformType() (configv1.PlatformType, error) {
 	}
 
 	return infra.Status.PlatformStatus.Type, nil
+}
+
+// GetControlPlaneTopology returns the current control plane topology mode.
+func (u *utils) GetControlPlaneTopology() (configv1.TopologyMode, error) {
+	infra := &configv1.Infrastructure{}
+	err := u.Get(context.Background(), clientOptions.ObjectKey{Name: "cluster"}, infra)
+	if err != nil {
+		return "", err
+	}
+	return infra.Status.ControlPlaneTopology, nil
 }
 
 func (u *utils) GetPodLogs(namespace string, pod *corev1.Pod) (string, error) {

--- a/test/e2e/nftables_test.go
+++ b/test/e2e/nftables_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Nftables", func() {
 
 		nodeName := nodeList.Items[0].Name
 		By("Rebooting first node: " + nodeName + "and waiting for disconnect \n")
-		err = node.SoftRebootNodeAndWaitForDisconnect(utilsHelpers, cs, nodeName, testNS, isSNO)
+		err = node.SoftRebootNodeAndWaitForDisconnect(utilsHelpers, cs, nodeName, testNS, controlPlaneTopology)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for node to be ready")

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Validation", func() {
 		}
 
 		// Asuming telco partenrs are using only none type and aws platform types for sno clusters.
-		if isSNO {
+		if controlPlaneTopology == configv1.SingleReplicaTopologyMode {
 			docType += "-sno"
 		}
 		docCommatrixFilePath := fmt.Sprintf(docCommatrixBaseFilePath, docType)


### PR DESCRIPTION
Previously, Commatrix used a function (**IsSNOCluster**) to detect single-node clusters implicitly. Now we explicitly define supported topologies using SupportedTopologies:

- SingleReplica → SNO

- HighlyAvailable → multi-node

- External → HyperShift

**If the detected control plane topology is not one of these, Commatrix will fail fast and return a clear error.**


The change prevents running Commatrix on unsupported cluster topologies (e.g., Aribter with dual-replica), which caused test failures. Explicitly listing supported topologies ensures:

Clear scope of supported clusters

Safe, predictable behavior

Future-proof extension when new topologies are added