### PR TITLE
[release-4.20] update the endpointslice to filter ports that are on localhost on the containerport

### DIFF
--- a/pkg/endpointslices/endpointslices.go
+++ b/pkg/endpointslices/endpointslices.go
@@ -113,7 +113,13 @@ func (ep *EndpointSlicesExporter) LoadExposedEndpointSlicesInfo() error {
 			if len(ports) == 0 {
 				continue
 			}
-			epl.Items[0].Ports = ports
+			// Exclude ports explicitly bound to localhost (127.0.0.1 or ::1)
+			epsPortsInfo := getEndpointSlicePortsFromPod(pods.Items[0], ports)
+			portsNoLocalhost := filterOutLocalhostPorts(epsPortsInfo)
+			if len(portsNoLocalhost) == 0 {
+				continue
+			}
+			epl.Items[0].Ports = portsNoLocalhost
 		}
 		epsliceInfo := createEPSliceInfo(service, epl.Items[0], pods.Items)
 		log.Debug("epsliceInfo created", epsliceInfo)

--- a/pkg/endpointslices/filter.go
+++ b/pkg/endpointslices/filter.go
@@ -42,6 +42,19 @@ func filterEndpointPortsByPodHostPort(portsInfo []EndpointPortInfo) []discoveryv
 	return filteredPorts
 }
 
+// filterOutLocalhostPorts returns endpoint ports from the given pod
+// but excludes any port entries explicitly bound to localhost (127.0.0.1 or ::1).
+func filterOutLocalhostPorts(portsInfo []EndpointPortInfo) []discoveryv1.EndpointPort {
+	filtered := make([]discoveryv1.EndpointPort, 0, len(portsInfo))
+	for _, pi := range portsInfo {
+		if pi.ContainerPort.HostIP == "127.0.0.1" || pi.ContainerPort.HostIP == "::1" {
+			continue
+		}
+		filtered = append(filtered, pi.EndpointPort)
+	}
+	return filtered
+}
+
 // filterHostNetwork checks if the pods behind the endpointSlice are host network.
 func isHostNetworked(pod corev1.Pod) bool {
 	// Assuming all pods in an EndpointSlice are uniformly on host network or not, we only check the first one.


### PR DESCRIPTION
cherry pick https://github.com/openshift-kni/commatrix/pull/325

- filter localhost container ports since they are not externally exposed
- unit test thats checking the filter function
Cherry-picking directly from the GitHub commit didn’t work because the changes depend on fields introduced in version 4.21 (specifically, the nodeRole was renamed to nodeGroup). In our tests commatrix created nodes reflecting this new change, which don’t exist in 4.20.

Since 4.20 lacks the updated machine configuration, and the test relied on a fake client, I applied the changes manually to make them compatible with 4.20.