### PR TITLE
[release-4.20] Remove machine config operator 9637

### DIFF
--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -14,16 +14,6 @@ var GeneralStaticEntriesWorker = []ComDetails{
 	}, {
 		Direction: "Ingress",
 		Protocol:  "TCP",
-		Port:      9637,
-		NodeRole:  "worker",
-		Service:   "kube-rbac-proxy-crio",
-		Namespace: "openshift-machine-config-operator",
-		Pod:       "kube-rbac-proxy-crio",
-		Container: "kube-rbac-proxy-crio",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
 		Port:      10250,
 		NodeRole:  "worker",
 		Service:   "kubelet",
@@ -84,16 +74,6 @@ var GeneralStaticEntriesMaster = []ComDetails{
 		Namespace: "openshift-network-operator",
 		Pod:       "network-operator",
 		Container: "network-operator",
-		Optional:  false,
-	}, {
-		Direction: "Ingress",
-		Protocol:  "TCP",
-		Port:      9637,
-		NodeRole:  "master",
-		Service:   "kube-rbac-proxy-crio",
-		Namespace: "openshift-machine-config-operator",
-		Pod:       "kube-rbac-proxy-crio",
-		Container: "kube-rbac-proxy-crio",
 		Optional:  false,
 	}, {
 		Direction: "Ingress",


### PR DESCRIPTION
Manually cherry-picked https://github.com/openshift-kni/commatrix/pull/336
 due to the missing nodeGroup field in release 4.20. This field exists only in 4.21+, so the change was applied manually.