### PR TITLE
Remove Linux Dynamic ranges from generated communication matrix

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -701,8 +701,8 @@ func TestButaneAndMCOutputFiles(t *testing.T) {
 					"machineconfiguration.openshift.io/role: master",
 					"nftables.service",
 					"/etc/sysconfig/nftables.conf",
-					"tcp dport { 22, 80, 111, 9107, 10250, 10256, 30000-60999 } accept",
-					"udp dport { 111, 6081, 30000-60999 } accept",
+					"tcp dport { 22, 80, 111, 9107, 10250, 10256, 30000-32767 } accept",
+					"udp dport { 111, 6081, 30000-32767 } accept",
 				},
 				"node-disruption-policy.yaml": {
 					"oc patch machineconfiguration cluster",
@@ -726,8 +726,8 @@ func TestButaneAndMCOutputFiles(t *testing.T) {
 					"machineconfiguration.openshift.io/role: master",
 					"nftables.service",
 					"/etc/sysconfig/nftables.conf",
-					"tcp dport { 22, 80, 111, 5355, 9107, 10250, 10256, 30000-60999 } accept",
-					"udp dport { 111, 5356, 6081, 30000-60999 } accept",
+					"tcp dport { 22, 80, 111, 5355, 9107, 10250, 10256, 30000-32767 } accept",
+					"udp dport { 111, 5356, 6081, 30000-32767 } accept",
 				},
 				"node-disruption-policy.yaml": {
 					"oc patch machineconfiguration cluster",

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -118,7 +118,7 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 	staticEntries = ExpandStaticEntriesByPool(staticEntries, PoolRolesForStaticEntriesExpansion)
 	epSliceComDetails = append(epSliceComDetails, staticEntries...)
 
-	dynamicRanges, err := dynamicranges.GetDynamicRanges(cm.exporter, cm.utilsHelpers)
+	dynamicRanges, err := dynamicranges.GetDynamicRanges(cm.exporter)
 	if err != nil {
 		log.Errorf("Failed to get dynamic ranges: %v", err)
 		return nil, fmt.Errorf("failed to get dynamic ranges: %w", err)

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift-kni/commatrix/pkg/client"
-	"github.com/openshift-kni/commatrix/pkg/consts"
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	matrixdiff "github.com/openshift-kni/commatrix/pkg/matrix-diff"
 	"github.com/openshift-kni/commatrix/pkg/types"
@@ -652,27 +651,6 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			// Set up mock utils to avoid pod creation in tests
 			ctrl = gomock.NewController(g.GinkgoT())
 			mockUtils = mock_utils.NewMockUtilsInterface(ctrl)
-
-			// Mock all the utils calls needed for getLinuxDynamicPrivateRange
-			mockUtils.EXPECT().CreateNamespace(consts.DefaultDebugNamespace).Return(nil).AnyTimes()
-			mockUtils.EXPECT().DeleteNamespace(consts.DefaultDebugNamespace).Return(nil).AnyTimes()
-
-			// Create a mock pod
-			mockPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "debug-pod",
-					Namespace: consts.DefaultDebugNamespace,
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				},
-			}
-			mockUtils.EXPECT().CreatePodOnNode(gomock.Any(), consts.DefaultDebugNamespace, gomock.Any(), gomock.Any()).Return(mockPod, nil).AnyTimes()
-			mockUtils.EXPECT().DeletePod(mockPod).Return(nil).AnyTimes()
-			mockUtils.EXPECT().WaitForPodStatus(consts.DefaultDebugNamespace, mockPod, corev1.PodRunning).Return(nil).AnyTimes()
-
-			// Mock the command output to return a default port range
-			mockUtils.EXPECT().RunCommandOnPod(mockPod, gomock.Any()).Return([]byte("32768 60999\n"), nil).AnyTimes()
 			mockUtils.EXPECT().ListNodes().Return([]corev1.Node{*testNode, *testNodeWorker}, nil).AnyTimes()
 		})
 

--- a/pkg/dynamic-ranges/dynamic-ranges.go
+++ b/pkg/dynamic-ranges/dynamic-ranges.go
@@ -6,42 +6,15 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift-kni/commatrix/pkg/consts"
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
-	"github.com/openshift-kni/commatrix/pkg/utils"
 	configv1 "github.com/openshift/api/config/v1"
 	clientOptions "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetDynamicRanges(exporter *endpointslices.EndpointSlicesExporter, utilsHelpers utils.UtilsInterface) (types.DynamicRangeList, error) {
-	log.Debug("Getting dynamic ranges")
-
-	dynamicRanges := types.DynamicRangeList{}
-
-	nodePortDynamicRange, err := getNodePortDynamicRange(exporter)
-	if err != nil {
-		log.Errorf("Failed to get node port dynamic range: %v", err)
-		return nil, fmt.Errorf("failed to get node port dynamic range: %w", err)
-	}
-	dynamicRanges = append(dynamicRanges, nodePortDynamicRange...)
-
-	linuxDynamicPrivateRange, err := getLinuxDynamicPrivateRange(exporter, utilsHelpers)
-	if err != nil {
-		log.Errorf("Failed to get Linux dynamic private range: %v", err)
-		return nil, fmt.Errorf("failed to get Linux dynamic private range: %w", err)
-	}
-	dynamicRanges = append(dynamicRanges, linuxDynamicPrivateRange...)
-
-	return dynamicRanges, nil
-}
-
-// GetNodePortDynamicRange returns the cluster's Service NodePort range as dynamic ranges.
-// If the cluster does not define a custom range, it falls back to the Kubernetes default (30000-32767).
-func getNodePortDynamicRange(exporter *endpointslices.EndpointSlicesExporter) (types.DynamicRangeList, error) {
+// GetDynamicRanges returns the cluster's Service NodePort range as dynamic ranges.
+func GetDynamicRanges(exporter *endpointslices.EndpointSlicesExporter) (types.DynamicRangeList, error) {
 	log.Debug("Getting node port dynamic range")
 	network := &configv1.Network{}
 	if err := exporter.Get(context.TODO(), clientOptions.ObjectKey{Name: "cluster"}, network); err != nil {
@@ -78,89 +51,6 @@ func getNodePortDynamicRange(exporter *endpointslices.EndpointSlicesExporter) (t
 			MaxPort:     maxPort,
 			Description: "Kubelet node ports",
 			Optional:    false,
-		},
-	}, nil
-}
-
-// getLinuxDynamicPrivateRange retrieves the Linux dynamic/private port range from a cluster node
-// by reading the host sysctl:
-//   - /proc/sys/net/ipv4/ip_local_port_range
-func getLinuxDynamicPrivateRange(exporter *endpointslices.EndpointSlicesExporter, utilsHelpers utils.UtilsInterface) (types.DynamicRangeList, error) {
-	log.Debug("Getting Linux dynamic/private port range from cluster")
-
-	// Pick an arbitrary node to query (ranges are expected to be consistent across nodes).
-	nodes, err := exporter.CoreV1Interface.Nodes().List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		log.Errorf("Failed to list nodes: %v", err)
-		return nil, fmt.Errorf("failed to list nodes: %w", err)
-	}
-	if len(nodes.Items) == 0 {
-		return nil, fmt.Errorf("no nodes found in the cluster")
-	}
-	nodeName := nodes.Items[0].Name
-
-	// Ensure namespace exists.
-	if err := utilsHelpers.CreateNamespace(consts.DefaultDebugNamespace); err != nil {
-		log.Errorf("Failed to create debug namespace: %v", err)
-		return nil, fmt.Errorf("failed to create debug namespace: %w", err)
-	}
-	defer func() {
-		if delErr := utilsHelpers.DeleteNamespace(consts.DefaultDebugNamespace); delErr != nil {
-			log.Warnf("failed to delete namespace %s: %v", consts.DefaultDebugNamespace, delErr)
-		}
-	}()
-
-	// Create a privileged pod on the selected node.
-	pod, err := utilsHelpers.CreatePodOnNode(nodeName, consts.DefaultDebugNamespace, consts.DefaultDebugPodImage, []string{})
-	if err != nil {
-		log.Errorf("Failed to create debug pod: %v", err)
-		return nil, fmt.Errorf("failed to create debug pod: %w", err)
-	}
-	defer func() {
-		if delErr := utilsHelpers.DeletePod(pod); delErr != nil {
-			log.Warnf("failed to delete debug pod %s: %v", pod.Name, delErr)
-		}
-	}()
-
-	// Wait for the pod to be running.
-	if err := utilsHelpers.WaitForPodStatus(consts.DefaultDebugNamespace, pod, corev1.PodRunning); err != nil {
-		log.Errorf("Debug pod did not reach Running state: %v", err)
-		return nil, fmt.Errorf("debug pod did not reach Running state: %w", err)
-	}
-
-	// Read IPv4 range (applies to both IPv4 and IPv6 ephemeral ports).
-	out, err := utilsHelpers.RunCommandOnPod(pod, []string{"/bin/sh", "-c", "cat /host/proc/sys/net/ipv4/ip_local_port_range"})
-	if err != nil {
-		log.Errorf("Failed to read IPv4 ip_local_port_range: %v", err)
-		return nil, fmt.Errorf("failed to read IPv4 ip_local_port_range: %w", err)
-	}
-	// If not set or empty, fall back to the Linux default dynamic/private range.
-	if strings.TrimSpace(string(out)) == "" {
-		log.Debug("ip_local_port_range not set; using Linux default dynamic/private range")
-		return types.LinuxDynamicPrivateDefaultDynamicRange, nil
-	}
-	minPort, maxPort, err := types.ParsePortRangeSpace(string(out))
-	if err != nil {
-		log.Errorf("Failed to parse IPv4 ip_local_port_range output: %v", err)
-		return nil, fmt.Errorf("failed to parse IPv4 ip_local_port_range: %w", err)
-	}
-
-	return types.DynamicRangeList{
-		{
-			Direction:   "Ingress",
-			Protocol:    "TCP",
-			MinPort:     minPort,
-			MaxPort:     maxPort,
-			Description: "Linux dynamic/private ports",
-			Optional:    true,
-		},
-		{
-			Direction:   "Ingress",
-			Protocol:    "UDP",
-			MinPort:     minPort,
-			MaxPort:     maxPort,
-			Description: "Linux dynamic/private ports",
-			Optional:    true,
 		},
 	}, nil
 }

--- a/pkg/dynamic-ranges/dynamic-ranges_test.go
+++ b/pkg/dynamic-ranges/dynamic-ranges_test.go
@@ -5,7 +5,6 @@ import (
 	o "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfigurationv1 "github.com/openshift/api/machineconfiguration/v1"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,10 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift-kni/commatrix/pkg/client"
-	"github.com/openshift-kni/commatrix/pkg/consts"
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
-	mock_utils "github.com/openshift-kni/commatrix/pkg/utils/mock"
 )
 
 func newExporterWithObjects(objs ...rtclient.Object) *endpointslices.EndpointSlicesExporter {
@@ -53,7 +50,7 @@ var _ = g.Describe("Dynamic Ranges", func() {
 			}
 			exporter := newExporterWithObjects(network)
 
-			got, err := getNodePortDynamicRange(exporter)
+			got, err := GetDynamicRanges(exporter)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			o.Expect(got).To(o.Equal(types.KubeletNodePortDefaultDynamicRange))
 		})
@@ -65,7 +62,7 @@ var _ = g.Describe("Dynamic Ranges", func() {
 			}
 			exporter := newExporterWithObjects(network)
 
-			got, err := getNodePortDynamicRange(exporter)
+			got, err := GetDynamicRanges(exporter)
 			o.Expect(err).ToNot(o.HaveOccurred())
 			o.Expect(got).To(o.HaveLen(2))
 			o.Expect(got[0].MinPort).To(o.Equal(10000))
@@ -73,89 +70,6 @@ var _ = g.Describe("Dynamic Ranges", func() {
 			o.Expect(got[0].Protocol).To(o.Equal("TCP"))
 			o.Expect(got[1].MinPort).To(o.Equal(10000))
 			o.Expect(got[1].MaxPort).To(o.Equal(10100))
-			o.Expect(got[1].Protocol).To(o.Equal("UDP"))
-		})
-	})
-
-	g.Context("Linux dynamic/private range", func() {
-		g.It("returns default range", func() {
-			// Need at least one node to select
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "node-0",
-					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
-				},
-			}
-			exporter := newExporterWithObjects(node)
-
-			ctrl := gomock.NewController(g.GinkgoT())
-			defer ctrl.Finish()
-
-			mockUtils := mock_utils.NewMockUtilsInterface(ctrl)
-
-			mockUtils.EXPECT().CreateNamespace(consts.DefaultDebugNamespace).Return(nil)
-			mockUtils.EXPECT().DeleteNamespace(consts.DefaultDebugNamespace).Return(nil)
-
-			// Pod lifecycle
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "debug-pod",
-					Namespace: consts.DefaultDebugNamespace,
-				},
-				Status: corev1.PodStatus{Phase: corev1.PodRunning},
-			}
-			mockUtils.EXPECT().CreatePodOnNode(gomock.Any(), consts.DefaultDebugNamespace, gomock.Any(), gomock.Any()).Return(pod, nil)
-			mockUtils.EXPECT().DeletePod(pod).Return(nil)
-			mockUtils.EXPECT().WaitForPodStatus(consts.DefaultDebugNamespace, pod, corev1.PodRunning).Return(nil)
-
-			// Simulate ip_local_port_range not set (empty output)
-			mockUtils.EXPECT().RunCommandOnPod(pod, gomock.Any()).Return([]byte(""), nil)
-
-			got, err := getLinuxDynamicPrivateRange(exporter, mockUtils)
-			o.Expect(err).ToNot(o.HaveOccurred())
-			o.Expect(got).To(o.Equal(types.LinuxDynamicPrivateDefaultDynamicRange))
-		})
-
-		g.It("uses range from pod value", func() {
-			// Need at least one node to select
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "node-0",
-					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
-				},
-			}
-			exporter := newExporterWithObjects(node)
-
-			ctrl := gomock.NewController(g.GinkgoT())
-			defer ctrl.Finish()
-
-			mockUtils := mock_utils.NewMockUtilsInterface(ctrl)
-
-			mockUtils.EXPECT().CreateNamespace(consts.DefaultDebugNamespace).Return(nil)
-			mockUtils.EXPECT().DeleteNamespace(consts.DefaultDebugNamespace).Return(nil)
-
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "debug-pod",
-					Namespace: consts.DefaultDebugNamespace,
-				},
-				Status: corev1.PodStatus{Phase: corev1.PodRunning},
-			}
-			mockUtils.EXPECT().CreatePodOnNode(gomock.Any(), consts.DefaultDebugNamespace, gomock.Any(), gomock.Any()).Return(pod, nil)
-			mockUtils.EXPECT().DeletePod(pod).Return(nil)
-			mockUtils.EXPECT().WaitForPodStatus(consts.DefaultDebugNamespace, pod, corev1.PodRunning).Return(nil)
-
-			// Custom ephemeral range values
-			mockUtils.EXPECT().RunCommandOnPod(pod, gomock.Any()).Return([]byte("40000 50000\n"), nil)
-
-			got, err := getLinuxDynamicPrivateRange(exporter, mockUtils)
-			o.Expect(err).ToNot(o.HaveOccurred())
-			o.Expect(got).To(o.HaveLen(2))
-			o.Expect(got[0].MinPort).To(o.Equal(40000))
-			o.Expect(got[0].MaxPort).To(o.Equal(50000))
-			o.Expect(got[0].Protocol).To(o.Equal("TCP"))
-			o.Expect(got[1].MinPort).To(o.Equal(40000))
-			o.Expect(got[1].MaxPort).To(o.Equal(50000))
 			o.Expect(got[1].Protocol).To(o.Equal("UDP"))
 		})
 	})

--- a/pkg/types/static-custom-entries.go
+++ b/pkg/types/static-custom-entries.go
@@ -381,25 +381,6 @@ var KubeletNodePortDefaultDynamicRange = DynamicRangeList{
 	},
 }
 
-var LinuxDynamicPrivateDefaultDynamicRange = DynamicRangeList{
-	{
-		Direction:   "Ingress",
-		Protocol:    "TCP",
-		MinPort:     32768,
-		MaxPort:     60999,
-		Description: "Linux dynamic/private ports",
-		Optional:    true,
-	},
-	{
-		Direction:   "Ingress",
-		Protocol:    "UDP",
-		MinPort:     32768,
-		MaxPort:     60999,
-		Description: "Linux dynamic/private ports",
-		Optional:    true,
-	},
-}
-
 // GetStaticEntries returns the static entries for the given platform, topology,
 // IPv6 and DHCP configuration.
 func GetStaticEntries(platformType configv1.PlatformType, topology configv1.TopologyMode, ipv6Enabled, dhcpEnabled bool) ([]ComDetails, error) {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -108,7 +108,6 @@ var _ = g.Describe("Dynamic range parsing and helpers", func() {
 				"Direction,Protocol,Port,Namespace,Service,Pod,Container,NodeGroup,Optional\n" +
 					"Ingress,TCP,443,ns1,svc1,pod1,ctr1,master,false\n" +
 					"Egress,UDP,30000-30100,,NodePort range,,,,true\n" +
-					"Ingress,TCP,49152-65535,,Linux ephemeral range,,,,true\n" +
 					"Egress,TCP,,,,,,worker,false\n", // empty Port should be skipped
 			)
 
@@ -129,23 +128,13 @@ var _ = g.Describe("Dynamic range parsing and helpers", func() {
 			o.Expect(cm.Ports[0].Optional).To(o.BeFalse())
 
 			// Dynamic ranges
-			o.Expect(cm.DynamicRanges).To(o.HaveLen(2))
-
-			// First range
+			o.Expect(cm.DynamicRanges).To(o.HaveLen(1))
 			o.Expect(cm.DynamicRanges[0].Direction).To(o.Equal("Egress"))
 			o.Expect(cm.DynamicRanges[0].Protocol).To(o.Equal("UDP"))
 			o.Expect(cm.DynamicRanges[0].MinPort).To(o.Equal(30000))
 			o.Expect(cm.DynamicRanges[0].MaxPort).To(o.Equal(30100))
 			o.Expect(cm.DynamicRanges[0].Description).To(o.Equal("NodePort range"))
 			o.Expect(cm.DynamicRanges[0].Optional).To(o.BeTrue())
-
-			// Second range
-			o.Expect(cm.DynamicRanges[1].Direction).To(o.Equal("Ingress"))
-			o.Expect(cm.DynamicRanges[1].Protocol).To(o.Equal("TCP"))
-			o.Expect(cm.DynamicRanges[1].MinPort).To(o.Equal(49152))
-			o.Expect(cm.DynamicRanges[1].MaxPort).To(o.Equal(65535))
-			o.Expect(cm.DynamicRanges[1].Description).To(o.Equal("Linux ephemeral range"))
-			o.Expect(cm.DynamicRanges[1].Optional).To(o.BeTrue())
 		})
 
 		g.It("errors on malformed dynamic range in CSV", func() {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -93,7 +93,6 @@ var _ = Describe("Validation", func() {
 		docComMatrix, err := types.ParseToComMatrix(docCommatrixFileContent, types.FormatCSV)
 		Expect(err).ToNot(HaveOccurred(), "Failed to parse documented communication matrix")
 		docComMatrix.DynamicRanges = append(docComMatrix.DynamicRanges, types.KubeletNodePortDefaultDynamicRange...)
-		docComMatrix.DynamicRanges = append(docComMatrix.DynamicRanges, types.LinuxDynamicPrivateDefaultDynamicRange...)
 
 		By("generating diff between matrices for testing purposes")
 		endpointslicesDiffWithDocMat := matrixdiff.Generate(commatrix, docComMatrix)


### PR DESCRIPTION
This PR removes the linux dynamic ranges from the commatrix, as it includes the entire range of the available ports - hence applying firewall on the matrix with this range will cause the all possible ports open instead of limitting access.