### PR TITLE
Add webhook port 9443 (cloud-controller-manager-operator) to AWS docs

### DIFF
--- a/docs/stable/raw/aws-sno.csv
+++ b/docs/stable/raw/aws-sno.csv
@@ -18,6 +18,7 @@ Ingress,TCP,9107,openshift-ovn-kubernetes,egressip-node-healthcheck,ovnkube-node
 Ingress,TCP,9108,openshift-ovn-kubernetes,ovn-kubernetes-control-plane,ovnkube-control-plane,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9192,openshift-cluster-machine-approver,machine-approver,machine-approver,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cluster-cloud-controller-manager,cluster-cloud-controller-manager,master,FALSE
+Ingress,TCP,9443,openshift-cloud-controller-manager-operator,cloud-controller-manager-operator,cluster-cloud-controller-manager-operator,cluster-cloud-controller-manager,master,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
 Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
 Ingress,TCP,9979,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE

--- a/docs/stable/raw/aws.csv
+++ b/docs/stable/raw/aws.csv
@@ -16,6 +16,7 @@ Ingress,TCP,9107,openshift-ovn-kubernetes,egressip-node-healthcheck,ovnkube-node
 Ingress,TCP,9108,openshift-ovn-kubernetes,ovn-kubernetes-control-plane,ovnkube-control-plane,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9192,openshift-cluster-machine-approver,machine-approver,machine-approver,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cluster-cloud-controller-manager,cluster-cloud-controller-manager,master,FALSE
+Ingress,TCP,9443,openshift-cloud-controller-manager-operator,cloud-controller-manager-operator,cluster-cloud-controller-manager-operator,cluster-cloud-controller-manager,master,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
 Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
 Ingress,TCP,9979,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE

--- a/docs/stable/unique/aws-sno.csv
+++ b/docs/stable/unique/aws-sno.csv
@@ -1,4 +1,5 @@
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
+Ingress,TCP,9443,openshift-cloud-controller-manager-operator,cloud-controller-manager-operator,cluster-cloud-controller-manager-operator,cluster-cloud-controller-manager,master,FALSE
 Ingress,TCP,80,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE

--- a/docs/stable/unique/aws.csv
+++ b/docs/stable/unique/aws.csv
@@ -1,4 +1,5 @@
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
+Ingress,TCP,9443,openshift-cloud-controller-manager-operator,cloud-controller-manager-operator,cluster-cloud-controller-manager-operator,cluster-cloud-controller-manager,master,FALSE
 Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
 Ingress,TCP,80,openshift-ingress,router-default,router-default,router,worker,FALSE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,worker,FALSE


### PR DESCRIPTION
The cloud-controller-manager-operator added a new service https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/433 for the
webhook on port 9443. The webhook server is only started when webhooks
are registered, so it doesn't appear in ss output, but the port should
be documented to ensure it is not blocked.