### PR TITLE
Skip rpc.statd, dnsmasq and dig port in validation test comparing ss to EPS matrix

### DIFF
--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -155,11 +155,11 @@ var _ = Describe("Validation", func() {
 			logrus.Warningf("the following ports are not used: \n %s", notUsedEPSMat)
 		}
 
+		missingEPSMat = filterOutPortsOfKnownServices(missingEPSMat)
 		// Don't include in the missing EPS matrix ports that are in dynamic ranges of the generated commatrix.
 		missingEPSMat = filterOutPortsInDynamicRanges(missingEPSMat, commatrix.DynamicRanges)
 		if len(missingEPSMat.Ports) > 0 {
-			err := fmt.Errorf("the following ports are used but don't have an endpointslice: \n %s", missingEPSMat)
-			Expect(err).ToNot(HaveOccurred(), "Failed to filter the known ports")
+			Fail(fmt.Sprintf("the following ports are used but don't have an endpointslice: \n %s", missingEPSMat))
 		}
 	})
 
@@ -231,6 +231,26 @@ var _ = Describe("Validation", func() {
 // by ss as a listening socket, so it's skipped in the open ports validation.
 func isDHCPClientPort(cd types.ComDetails) bool {
 	return cd.Protocol == "UDP" && cd.Port == 68
+}
+
+func filterOutPortsOfKnownServices(mat *types.ComMatrix) *types.ComMatrix {
+	res := []types.ComDetails{}
+	for _, cd := range mat.Ports {
+		// Skip "rpc.statd" ports, these are randomly open ports on the node
+		// no need to mention them in the matrix diff
+		if cd.Service == "rpc.statd" {
+			continue
+		}
+
+		// Skip dns ports used during provisioning for dhcp and tftp,
+		// not used for external traffic
+		if cd.Service == "dnsmasq" || cd.Service == "dig" {
+			continue
+		}
+
+		res = append(res, cd)
+	}
+	return &types.ComMatrix{Ports: res}
 }
 
 func filterOutPortsInDynamicRanges(mat *types.ComMatrix, dynamicRanges []types.DynamicRange) *types.ComMatrix {


### PR DESCRIPTION
rpc.statd ports are randomly open ports on the node when using NFS, we decided to skip those ports in the validation test and update the document to say - that if NFS is used, those ports or the dynamic linux range should be added as additional static entries to the generated commatrix. 
dns ports are used during provisioning for dhcp and tftp, and can be blocked, hence are skipped in the test (except dhcp 68 port which was added to the static entries to ensure that it won't be blocked - see [PR#415](https://github.com/openshift-kni/commatrix/pull/415))