### PR TITLE
Enable unparam check-exported and fix flagged issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,8 @@ linters-settings:
     disabled-checks:
       - captLocal
       - exitAfterDefer
+  unparam:
+    check-exported: true
   revive:
     rules:
     - name: receiver-naming

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -413,12 +413,9 @@ func generateMatrix(o *GenerateOptions, controlPlaneTopology configv1.TopologyMo
 	if dhcpEnabled {
 		opts = append(opts, commatrixcreator.WithDHCP())
 	}
-	commMatrix, err := commatrixcreator.New(
+	commMatrix := commatrixcreator.New(
 		platformType, controlPlaneTopology, opts...,
 	)
-	if err != nil {
-		return nil, err
-	}
 
 	matrix, err := commMatrix.CreateEndpointMatrix()
 	if err != nil {
@@ -434,7 +431,7 @@ func generateSS(o *GenerateOptions) (*listeningsockets.SSResult, error) {
 	}
 
 	log.Debug("Creating listening socket check")
-	listeningCheck, err := listeningsockets.NewCheck(o.cs, o.utilsHelpers, o.destDir, o.customNodeGroups)
+	listeningCheck, err := listeningsockets.NewCheck(o.cs, o.utilsHelpers, o.customNodeGroups)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating listening socket check: %v", err)
 	}

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -67,7 +67,7 @@ func New(
 	platformType configv1.PlatformType,
 	topology configv1.TopologyMode,
 	opts ...Option,
-) (*CommunicationMatrixCreator, error) {
+) *CommunicationMatrixCreator {
 	cm := &CommunicationMatrixCreator{
 		platformType:         platformType,
 		controlPlaneTopology: topology,
@@ -75,7 +75,7 @@ func New(
 	for _, o := range opts {
 		o(cm)
 	}
-	return cm, nil
+	return cm
 }
 
 // CreateEndpointMatrix initializes a ComMatrix using Kubernetes cluster data.
@@ -112,17 +112,13 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
-	PoolRolesForStaticEntriesExpansion, err := mcp.GetPoolRolesForStaticEntriesExpansion(nodes, cm.exporter.NodeToGroup())
-	if err != nil {
-		log.Errorf("Failed to extract pool to roles: %v", err)
-		return nil, err
-	}
+	PoolRolesForStaticEntriesExpansion := mcp.GetPoolRolesForStaticEntriesExpansion(nodes, cm.exporter.NodeToGroup())
 
 	// Expand static entries for all MCPs based on their roles
 	staticEntries = ExpandStaticEntriesByPool(staticEntries, PoolRolesForStaticEntriesExpansion)
 	epSliceComDetails = append(epSliceComDetails, staticEntries...)
 
-	dynamicRanges, err := dynamicranges.GetDynamicRanges(cm.exporter, cm.utilsHelpers, cm.exporter.ClientSet)
+	dynamicRanges, err := dynamicranges.GetDynamicRanges(cm.exporter, cm.utilsHelpers)
 	if err != nil {
 		log.Errorf("Failed to get dynamic ranges: %v", err)
 		return nil, fmt.Errorf("failed to get dynamic ranges: %w", err)

--- a/pkg/commatrix-creator/commatrix_test.go
+++ b/pkg/commatrix-creator/commatrix_test.go
@@ -318,7 +318,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 		for _, format := range []string{types.FormatCSV, types.FormatJSON, types.FormatYAML} {
 			g.It(fmt.Sprintf("Should successfully extract ComDetails from a %s file", format), func() {
 				g.By(fmt.Sprintf("Creating new communication matrix with %s static entries format", format))
-				cm, err := New(
+				cm := New(
 					configv1.BareMetalPlatformType,
 					configv1.HighlyAvailableTopologyMode,
 					WithCustomEntries(
@@ -326,7 +326,6 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 						format,
 					),
 				)
-				o.Expect(err).ToNot(o.HaveOccurred())
 
 				g.By("Getting ComMatrix From File")
 				gotComMatrix, err := cm.GetComMatrixFromFile()
@@ -340,7 +339,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to non-matched customEntriesPath and customEntriesFormat types", func() {
 			g.By("Creating new communication matrix with non-matched customEntriesPath and customEntriesFormat")
-			cm, err := New(
+			cm := New(
 				configv1.BareMetalPlatformType,
 				configv1.HighlyAvailableTopologyMode,
 				WithCustomEntries(
@@ -348,7 +347,6 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 					types.FormatJSON,
 				),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComMatrix From File")
 			gotComMatrix, err := cm.GetComMatrixFromFile()
@@ -360,7 +358,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid customEntriesFormat", func() {
 			g.By("Creating new communication matrix with invalid customEntriesFormat")
-			cm, err := New(
+			cm := New(
 				configv1.BareMetalPlatformType,
 				configv1.HighlyAvailableTopologyMode,
 				WithCustomEntries(
@@ -368,7 +366,6 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 					types.FormatNFT,
 				),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting ComMatrix From File")
 			gotComMatrix, err := cm.GetComMatrixFromFile()
@@ -382,11 +379,10 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 	g.Context("Get static entries from file", func() {
 		g.It("Should successfully get static entries suitable to baremetal standard cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal standard cluster")
-			cm, err := New(
+			cm := New(
 				configv1.BareMetalPlatformType,
 				configv1.HighlyAvailableTopologyMode,
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -400,11 +396,10 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to baremetal SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to baremetal SNO cluster")
-			cm, err := New(
+			cm := New(
 				configv1.BareMetalPlatformType,
 				configv1.SingleReplicaTopologyMode,
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -417,11 +412,10 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to None standard cluster", func() {
 			g.By("Creating new communication matrix suitable to None standard cluster")
-			cm, err := New(
+			cm := New(
 				configv1.NonePlatformType,
 				configv1.HighlyAvailableTopologyMode,
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -435,11 +429,10 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully get static entries suitable to None SNO cluster", func() {
 			g.By("Creating new communication matrix suitable to None SNO cluster")
-			cm, err := New(
+			cm := New(
 				configv1.NonePlatformType,
 				configv1.SingleReplicaTopologyMode,
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -452,12 +445,11 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should include DHCP static entries when dhcpEnabled is true on standard cluster", func() {
 			g.By("Creating new communication matrix with dhcpEnabled=true for standard cluster")
-			cm, err := New(
+			cm := New(
 				configv1.BareMetalPlatformType,
 				configv1.HighlyAvailableTopologyMode,
 				WithDHCP(),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -472,12 +464,11 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should include DHCP static entries when dhcpEnabled is true on SNO cluster", func() {
 			g.By("Creating new communication matrix with dhcpEnabled=true for SNO cluster")
-			cm, err := New(
+			cm := New(
 				configv1.BareMetalPlatformType,
 				configv1.SingleReplicaTopologyMode,
 				WithDHCP(),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -491,11 +482,10 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should return an error due to an invalid value for cluster environment", func() {
 			g.By("Creating new communication matrix with an invalid value for cluster environment")
-			cm, err := New(
+			cm := New(
 				"invalid",
 				configv1.SingleReplicaTopologyMode,
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Getting static entries comDetails of the created communication matrix")
 			gotComDetails, err := cm.GetStaticEntries()
@@ -570,7 +560,7 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix with custom entries", func() {
 			g.By("Creating new communication matrix with static entries")
-			commatrixCreator, err := New(
+			commatrixCreator := New(
 				configv1.AWSPlatformType,
 				configv1.SingleReplicaTopologyMode,
 				WithExporter(endpointSlices),
@@ -580,7 +570,6 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 					types.FormatCSV,
 				),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
@@ -603,13 +592,12 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should successfully create an endpoint matrix without custom entries", func() {
 			g.By("Creating new communication matrix without static entries")
-			commatrixCreator, err := New(
+			commatrixCreator := New(
 				configv1.AWSPlatformType,
 				configv1.SingleReplicaTopologyMode,
 				WithExporter(endpointSlices),
 				WithUtilsHelpers(mockUtils),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
@@ -628,14 +616,13 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 
 		g.It("Should include IPv6 static entries when ipv6Enabled is true on Standard", func() {
 			g.By("Creating communication matrix with ipv6Enabled=true for Standard")
-			commatrixCreator, err := New(
+			commatrixCreator := New(
 				configv1.AWSPlatformType,
 				configv1.HighlyAvailableTopologyMode,
 				WithExporter(endpointSlices),
 				WithUtilsHelpers(mockUtils),
 				WithIPv6(),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
@@ -683,13 +670,12 @@ var _ = g.Describe("Commatrix creator pkg tests", func() {
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Creating endpoint matrix")
-			commatrixCreator, err := New(
+			commatrixCreator := New(
 				configv1.AWSPlatformType,
 				configv1.SingleReplicaTopologyMode,
 				WithExporter(localhostEndpointSlices),
 				WithUtilsHelpers(mockUtils),
 			)
-			o.Expect(err).ToNot(o.HaveOccurred())
 			commatrix, err := commatrixCreator.CreateEndpointMatrix()
 			o.Expect(err).ToNot(o.HaveOccurred())
 

--- a/pkg/dynamic-ranges/dynamic-ranges.go
+++ b/pkg/dynamic-ranges/dynamic-ranges.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift-kni/commatrix/pkg/client"
 	"github.com/openshift-kni/commatrix/pkg/consts"
 	"github.com/openshift-kni/commatrix/pkg/endpointslices"
 	"github.com/openshift-kni/commatrix/pkg/types"
@@ -18,7 +17,7 @@ import (
 	clientOptions "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetDynamicRanges(exporter *endpointslices.EndpointSlicesExporter, utilsHelpers utils.UtilsInterface, cs *client.ClientSet) (types.DynamicRangeList, error) {
+func GetDynamicRanges(exporter *endpointslices.EndpointSlicesExporter, utilsHelpers utils.UtilsInterface) (types.DynamicRangeList, error) {
 	log.Debug("Getting dynamic ranges")
 
 	dynamicRanges := types.DynamicRangeList{}

--- a/pkg/listening-sockets/listening-sockets.go
+++ b/pkg/listening-sockets/listening-sockets.go
@@ -32,7 +32,7 @@ type ConnectionCheck struct {
 	nodeToGroup map[string]string
 }
 
-func NewCheck(c *client.ClientSet, podUtils utils.UtilsInterface, destDir string, customNodeGroups map[string]labels.Selector) (*ConnectionCheck, error) {
+func NewCheck(c *client.ClientSet, podUtils utils.UtilsInterface, customNodeGroups map[string]labels.Selector) (*ConnectionCheck, error) {
 	nodes, err := podUtils.ListNodes()
 	if err != nil {
 		return nil, err

--- a/pkg/listening-sockets/listening_sockets_test.go
+++ b/pkg/listening-sockets/listening_sockets_test.go
@@ -185,7 +185,7 @@ var _ = Describe("GenerateSS", func() {
 
 		mockUtils.EXPECT().DeletePod(mockPod).Return(nil).AnyTimes()
 
-		connectionCheck, err := NewCheck(clientset, mockUtils, "/some/dest/dir", nil)
+		connectionCheck, err := NewCheck(clientset, mockUtils, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		ssResult, err := connectionCheck.GenerateSS(consts.DefaultDebugNamespace)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -46,7 +46,7 @@ func poolNameFromRenderedConfig(currentConfig string) (string, bool) {
 
 // GetPoolRolesForStaticEntriesExpansion derives, per pool, which of [master, worker]
 // Are present on its nodes; used to expand role-scoped static entries across pools.
-func GetPoolRolesForStaticEntriesExpansion(nodes []corev1.Node, nodeToPool map[string]string) (map[string][]string, error) {
+func GetPoolRolesForStaticEntriesExpansion(nodes []corev1.Node, nodeToPool map[string]string) map[string][]string {
 	observedRoles := make(map[string][]string)
 	for _, node := range nodes {
 		_, hasmaster := node.Labels[consts.RoleLabel+"master"]
@@ -61,5 +61,5 @@ func GetPoolRolesForStaticEntriesExpansion(nodes []corev1.Node, nodeToPool map[s
 		}
 	}
 
-	return observedRoles, nil
+	return observedRoles
 }

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -97,8 +97,7 @@ var _ = Describe("GetPoolRolesForStaticEntriesExpansion", func() {
 
 		manualMap := map[string]string{"n1": "custom", "n2": "custom", "n3": "custom"}
 
-		roles, err := GetPoolRolesForStaticEntriesExpansion(nodes, manualMap)
-		Expect(err).NotTo(HaveOccurred())
+		roles := GetPoolRolesForStaticEntriesExpansion(nodes, manualMap)
 		Expect(roles["custom"]).To(ContainElements("master", "worker"))
 	})
 })

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -194,10 +194,9 @@ var _ = Describe("Validation", func() {
 		if dhcpEnabled {
 			opts = append(opts, commatrixcreator.WithDHCP())
 		}
-		cm, err := commatrixcreator.New(
+		cm := commatrixcreator.New(
 			platformType, controlPlaneTopology, opts...,
 		)
-		Expect(err).ToNot(HaveOccurred(), "Failed to create communication matrix creator")
 
 		By("Getting static entries suitable to the cluster")
 		staticEntries, err := cm.GetStaticEntries()
@@ -206,8 +205,7 @@ var _ = Describe("Validation", func() {
 		By("Expand static entries for all MCPs based on their roles")
 		nodes, err := utilsHelpers.ListNodes()
 		Expect(err).ToNot(HaveOccurred(), "Failed to list nodes")
-		PoolRolesForStaticEntriesExpansion, err := mcp.GetPoolRolesForStaticEntriesExpansion(nodes, exporter.NodeToGroup())
-		Expect(err).ToNot(HaveOccurred(), "Failed to get pool roles for static entries expansion")
+		PoolRolesForStaticEntriesExpansion := mcp.GetPoolRolesForStaticEntriesExpansion(nodes, exporter.NodeToGroup())
 		staticEntries = commatrixcreator.ExpandStaticEntriesByPool(staticEntries, PoolRolesForStaticEntriesExpansion)
 
 		By("Checking that all static entries are present in the ss (open ports) matrix")


### PR DESCRIPTION
## Summary
- Enable the `check-exported: true` setting for the `unparam` linter in `.golangci.yml` to catch unused parameters and always-nil error returns in exported functions.
- Fix the three issues it flagged:
  - `commatrix-creator.New()` always returned a nil error — drop the error return value and update all callers.
  - `dynamicranges.GetDynamicRanges()` had an unused `cs` parameter — remove it and update callers.
  - `listeningsockets.NewCheck()` had an unused `destDir` parameter — remove it and update callers.
  - mcp: GetPoolRolesForStaticEntriesExpansion() always returned nil error, drop error return 
