### PR TITLE
Update rpms-signature-scan task to trusted digest

### DIFF
--- a/.tekton/commatrix-4-22-pull-request.yaml
+++ b/.tekton/commatrix-4-22-pull-request.yaml
@@ -621,7 +621,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:3d48fa2fcc898bae9ce730a71789c34758a767b44bc36fd24938779deef4ee96
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/commatrix-4-22-push.yaml
+++ b/.tekton/commatrix-4-22-push.yaml
@@ -608,7 +608,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:3d48fa2fcc898bae9ce730a71789c34758a767b44bc36fd24938779deef4ee96
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Upgrade the `rpms-signature-scan` task bundle digest to the trusted version in both Tekton pipeline files (pull-request and push).
- Resolves EC policy violations `tasks.required_untrusted_task_found` and `trusted_task.trusted`.
