### PR TITLE
Update clamav-scan task to latest trusted version

### DIFF
--- a/.tekton/commatrix-4-21-pull-request.yaml
+++ b/.tekton/commatrix-4-21-pull-request.yaml
@@ -416,7 +416,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:4f5ccf2324ecef92aaad6e2adb46c0bb15be49b4869b5b407346c514b764404f
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/commatrix-4-21-push.yaml
+++ b/.tekton/commatrix-4-21-push.yaml
@@ -402,7 +402,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:4f5ccf2324ecef92aaad6e2adb46c0bb15be49b4869b5b407346c514b764404f
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Update the clamav-scan task bundle digest to the latest trusted version in both push and pull-request pipelines
- Fixes 6 release validation violations (tasks.required_untrusted_task_found and trusted_task.trusted) caused by an outdated clamav-scan digest

## Test plan
- [ ] Verify the release pipeline passes the conforma/EC validation without clamav-scan violations
