### PR TITLE
Improve empty kubeconfig error message

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,6 +31,14 @@ func New() (*ClientSet, error) {
 
 	restConfig, err := ctrl.GetConfig()
 	if err != nil {
+		if clientcmd.IsEmptyConfig(err) {
+			return nil, fmt.Errorf(
+				"failed to get Kubernetes config: could not build a cluster client config "+
+					"(in-cluster config is not available and no kubeconfig was loaded). "+
+					"Try --kubeconfig, set %s to a kubeconfig file path, or use ~/.kube/config",
+				clientcmd.RecommendedConfigPathEnvVar,
+			)
+		}
 		return nil, fmt.Errorf("failed to get Kubernetes config: %w", err)
 	}
 	clientSet := &ClientSet{}


### PR DESCRIPTION
## Summary

When no Kubernetes client configuration could be resolved, client-go still surfaces text that points users at the deprecated `KUBERNETES_MASTER` environment variable ([issue #430](https://github.com/openshift-kni/commatrix/issues/430)).

Detect the empty-config case with `clientcmd.IsEmptyConfig` and return a short message that matches how controller-runtime loads config: `--kubeconfig`, `KUBECONFIG`, and the default kubeconfig path.


Fixes https://github.com/openshift-kni/commatrix/issues/430