### PR TITLE
Fix Tekton pipeline target_branch for release-4.22

### DIFF
--- a/.tekton/commatrix-4-22-pull-request.yaml
+++ b/.tekton/commatrix-4-22-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "release-4.22"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: commatrix-4-22

--- a/.tekton/commatrix-4-22-push.yaml
+++ b/.tekton/commatrix-4-22-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "release-4.22"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: commatrix-4-22

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ raw-ss-tcp - The raw `ss` output for TCP.
 raw-ss-udp - The raw `ss` output for UDP.
 ```
 
+**Note:** The `ss-generated-matrix`, `matrix-diff-ss`, `raw-ss-tcp`, and `raw-ss-udp` artifacts are only generated for CSV, JSON, and YAML formats. For NFT, Butane, and MachineConfig formats, the ss results are merged into the communication matrix.
+
 Each record describes a flow with the following information:
 ```
 direction      Data flow direction (currently ingress only)

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -175,12 +175,12 @@ spec:
               serviceName: nftables.service
 ```
 
-`host-open-ports example command`
+`host-open-ports example command (csv/json/yaml)`
 ```sh
 $ oc commatrix generate --host-open-ports --format csv
 ```
 
-the command will generate the follwing paths:
+For CSV, JSON, and YAML formats, the command generates separate files:
 
 `communication-matrix path`
 
@@ -227,6 +227,16 @@ UNCONN 0      0      0.0.0.0:111   0.0.0.0:* users:(("rpcbind",pid=3919,fd=5),("
 UNCONN 0      0      127.0.0.1:323   0.0.0.0:* users:(("chronyd",pid=2805,fd=5))
 UNCONN 0      0      127.0.0.1:708   0.0.0.0:* users:(("rpc.statd",pid=3922,fd=8))
 ```
+
+`host-open-ports with nft/butane/mc formats`
+
+For NFT, Butane, and MachineConfig formats, `--host-open-ports` merges both the EndpointSlice-based matrix and the listening-sockets (ss) matrix into a single output file, rather than generating separate diff and ss-matrix files. Overlapping or adjacent port ranges are squashed together. This produces a complete set of firewall rules covering all known ports.
+
+```sh
+$ oc commatrix generate --host-open-ports --format butane
+```
+
+Some ports on the node may be open without a corresponding Service or EndpointSlice. Using `--host-open-ports` with these formats merges the `ss`-discovered ports into the output, giving a complete picture of all ports open on the nodes at that moment. The same merged behavior applies to `--format nft` and `--format mc`.
 
 `customEntriesFormat and customEntriesPath example command`
 ```sh


### PR DESCRIPTION
## Summary
- Update the `on-cel-expression` in both Tekton pipeline files (`commatrix-4-22-pull-request.yaml` and `commatrix-4-22-push.yaml`) to trigger on the `release-4.22` branch instead of `main`.

## Test plan
- [ ] Verify pull request pipeline triggers on PRs targeting `release-4.22`
- [ ] Verify push pipeline triggers on pushes to `release-4.22`

Made with [Cursor](https://cursor.com)