### PR TITLE
Fix Tekton pipeline target_branch for release-4.22

### DIFF
--- a/.tekton/commatrix-4-22-pull-request.yaml
+++ b/.tekton/commatrix-4-22-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "release-4.22"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: commatrix-4-22

--- a/.tekton/commatrix-4-22-push.yaml
+++ b/.tekton/commatrix-4-22-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "release-4.22"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: commatrix-4-22


### PR DESCRIPTION
## Summary
- Update the `on-cel-expression` in both Tekton pipeline files (`commatrix-4-22-pull-request.yaml` and `commatrix-4-22-push.yaml`) to trigger on the `release-4.22` branch instead of `main`.
