### PR TITLE
Rename Tekton pipelines from 4-22 to 5-0

### DIFF
--- a/.tekton/commatrix-5-0-pull-request.yaml
+++ b/.tekton/commatrix-5-0-pull-request.yaml
@@ -4,17 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift-kni/commatrix?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: commatrix-4-22
-    appstudio.openshift.io/component: commatrix-4-22
+    appstudio.openshift.io/application: commatrix-5-0
+    appstudio.openshift.io/component: commatrix-5-0
     pipelines.appstudio.openshift.io/type: build
-  name: commatrix-4-22-on-push
+  name: commatrix-5-0-on-pull-request
   namespace: commatrix-tenant
 spec:
   params:
@@ -23,7 +24,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/commatrix-tenant/commatrix-4-22:{{revision}}
+    value: quay.io/redhat-user-workloads/commatrix-tenant/commatrix-5-0:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
@@ -109,6 +112,10 @@ spec:
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -124,6 +131,9 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     tasks:
     - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
       taskRef:
         params:
         - name: name
@@ -221,6 +231,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -593,7 +607,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-commatrix-4-22
+    serviceAccountName: build-pipeline-commatrix-5-0
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/commatrix-5-0-push.yaml
+++ b/.tekton/commatrix-5-0-push.yaml
@@ -4,18 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift-kni/commatrix?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: commatrix-4-22
-    appstudio.openshift.io/component: commatrix-4-22
+    appstudio.openshift.io/application: commatrix-5-0
+    appstudio.openshift.io/component: commatrix-5-0
     pipelines.appstudio.openshift.io/type: build
-  name: commatrix-4-22-on-pull-request
+  name: commatrix-5-0-on-push
   namespace: commatrix-tenant
 spec:
   params:
@@ -24,9 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/commatrix-tenant/commatrix-4-22:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/commatrix-tenant/commatrix-5-0:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -112,10 +109,6 @@ spec:
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
-    - name: enable-cache-proxy
-      default: 'false'
-      description: Enable cache proxy configuration
-      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -131,9 +124,6 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     tasks:
     - name: init
-      params:
-      - name: enable-cache-proxy
-        value: $(params.enable-cache-proxy)
       taskRef:
         params:
         - name: name
@@ -231,10 +221,6 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
-      - name: HTTP_PROXY
-        value: $(tasks.init.results.http-proxy)
-      - name: NO_PROXY
-        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -607,7 +593,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-commatrix-4-22
+    serviceAccountName: build-pipeline-commatrix-5-0
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## Summary
- Remove the `commatrix-4-22` Tekton pipeline files from main branch.
- Add `commatrix-5-0` versions with all internal references updated (application, component, name, output-image, serviceAccountName).

## Test plan
- [ ] Verify the 5-0 pull-request pipeline triggers correctly on PRs to main
- [ ] Verify the 5-0 push pipeline triggers correctly on pushes to main
