### PR TITLE
Fix missing space in firewall log prefix for broadcast traffic

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -373,7 +373,7 @@ table inet openshift_filter {
         udp dport { %s } accept
 
         # Drop broadcast traffic with rate-limited logging
-        ip daddr 255.255.255.255 jump { limit rate 1/minute log prefix "firewall"; drop; }
+        ip daddr 255.255.255.255 jump { limit rate 1/minute log prefix "firewall "; drop; }
 
         # Rate-limited logging and default drop
         jump { limit rate 1/minute log prefix "firewall "; drop; }


### PR DESCRIPTION
## Summary
- Add trailing space to the nftables log prefix for broadcast traffic (`ip daddr 255.255.255.255`), matching the existing default drop rule
- Without the space, log entries appear as `firewallIN=...` instead of `firewall IN=...`

Fixes https://github.com/openshift-kni/commatrix/issues/466

🤖 Generated with [Claude Code](https://claude.com/claude-code)