### PR TITLE
CNF-23208: Upgrade golangci-lint from v1.63.4 to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,39 +1,42 @@
+version: "2"
 run:
   issues-exit-code: 2
+formatters:
+  enable:
+    - gofmt
+    - goimports
 linters:
   enable:
-  - godot
-  - goimports
-  - gofmt
-  - ginkgolinter
-  - dogsled
-  - copyloopvar
-  - gocritic
-  - misspell
-  - nolintlint
-  - stylecheck
-  - unconvert
-  - unparam
-  - whitespace
-  - revive
-  - unused
-  - wastedassign
-linters-settings:
-  godot:
-    scope: toplevel
-    capital: true
-    exclude:
-    - 'SPDX-License-Identifier.*'
-    - '\+groupName.*'
-  gocritic:
-    disabled-checks:
-      - captLocal
-      - exitAfterDefer
-  unparam:
-    check-exported: true
-  revive:
-    rules:
-    - name: receiver-naming
-      disabled: true
-    - name: dot-imports
-      disabled: true
+    - godot
+    - ginkgolinter
+    - dogsled
+    - copyloopvar
+    - gocritic
+    - misspell
+    - nolintlint
+    - staticcheck
+    - unconvert
+    - unparam
+    - whitespace
+    - revive
+    - unused
+    - wastedassign
+  settings:
+    godot:
+      scope: toplevel
+      capital: true
+      exclude:
+        - 'SPDX-License-Identifier.*'
+        - '\+groupName.*'
+    gocritic:
+      disabled-checks:
+        - captLocal
+        - exitAfterDefer
+    unparam:
+      check-exported: true
+    revive:
+      rules:
+        - name: receiver-naming
+          disabled: true
+        - name: dot-imports
+          disabled: true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GOLANGCI_LINT = $(BIN_DIR)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.63.4
+GOLANGCI_LINT_VER = v2.12.2
 
 # Output directory
 OUTPUT_DIR=$(CURPATH)/cross-build-output
@@ -102,11 +102,11 @@ check-deps: deps-update
 	exit 1; fi
 
 $(GOLANGCI_LINT): ; $(info installing golangci-lint...)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VER))
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(BIN_DIR) $(GOLANGCI_LINT_VER)
 
 .PHONY: lint
 lint: | $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run golangci-lint
-	GOFLAGS="" $(GOLANGCI_LINT) run --timeout=10m
+	GOFLAGS="" $(GOLANGCI_LINT) run
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GOLANGCI_LINT = $(BIN_DIR)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.63.4
+GOLANGCI_LINT_VER = v2.11.4
 
 # Output directory
 OUTPUT_DIR=$(CURPATH)/cross-build-output
@@ -102,11 +102,11 @@ check-deps: deps-update
 	exit 1; fi
 
 $(GOLANGCI_LINT): ; $(info installing golangci-lint...)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VER))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VER))
 
 .PHONY: lint
 lint: | $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run golangci-lint
-	GOFLAGS="" $(GOLANGCI_LINT) run --timeout=10m
+	GOFLAGS="" $(GOLANGCI_LINT) run
 
 .PHONY: test
 test:

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -270,7 +270,11 @@ func TestCommatrixGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Clean up after test
-	defer os.RemoveAll(destDir)
+	defer func() {
+		if err := os.RemoveAll(destDir); err != nil {
+			t.Logf("failed to clean up test directory %s: %v", destDir, err)
+		}
+	}()
 
 	ctrlTest := gomock.NewController(t)
 

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -148,7 +148,11 @@ func (cm *CommunicationMatrixCreator) GetComMatrixFromFile() (*types.ComMatrix, 
 		log.Errorf("Failed to open file %s: %v", cm.customEntriesPath, err)
 		return nil, fmt.Errorf("failed to open file %s: %w", cm.customEntriesPath, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Errorf("failed to close file %s: %v", cm.customEntriesPath, err)
+		}
+	}()
 
 	log.Debugf("Reading file %s", cm.customEntriesPath)
 	raw, err := io.ReadAll(f)

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -148,7 +148,11 @@ func (cm *CommunicationMatrixCreator) GetComMatrixFromFile() (*types.ComMatrix, 
 		log.Errorf("Failed to open file %s: %v", cm.customEntriesPath, err)
 		return nil, fmt.Errorf("failed to open file %s: %v", cm.customEntriesPath, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Errorf("failed to close file %s: %v", cm.customEntriesPath, err)
+		}
+	}()
 
 	log.Debugf("Reading file %s", cm.customEntriesPath)
 	raw, err := io.ReadAll(f)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -333,18 +333,20 @@ func (m *ComMatrix) ToNFTables() ([]byte, error) {
 	var tcpPorts []string
 	var udpPorts []string
 	for _, line := range m.Ports {
-		if line.Protocol == "TCP" {
+		switch line.Protocol {
+		case "TCP":
 			tcpPorts = append(tcpPorts, fmt.Sprint(line.Port))
-		} else if line.Protocol == "UDP" {
+		case "UDP":
 			udpPorts = append(udpPorts, fmt.Sprint(line.Port))
 		}
 	}
 
 	for _, dr := range m.DynamicRanges {
 		rangeStr := dr.PortRangeString()
-		if dr.Protocol == "TCP" {
+		switch dr.Protocol {
+		case "TCP":
 			tcpPorts = append(tcpPorts, rangeStr)
-		} else if dr.Protocol == "UDP" {
+		case "UDP":
 			udpPorts = append(udpPorts, rangeStr)
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -331,7 +331,7 @@ func (u *utils) GetPodLogs(namespace string, pod *corev1.Pod) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get log stream: %w", err)
 	}
-	defer logStream.Close()
+	defer func() { _ = logStream.Close() }()
 
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, logStream)


### PR DESCRIPTION
## Summary
- Upgrade golangci-lint from v1.63.4 to v2.12.2 (major version migration)
- Rewrite `.golangci.yml` to v2 config format (version declaration, formatters section, merged stylecheck->staticcheck, nested linters.settings)
- Update Makefile: version bump, switch to binary install via official install script, remove deprecated `--timeout` flag
- Fix 5 new lint findings surfaced by v2 (3 errcheck, 2 staticcheck)

## Details

### Makefile
- Version: `v1.63.4` -> `v2.12.2`
- Install method: switched from `go install` to official install script (`curl | sh`) to download pre-built binaries — avoids Go version constraints from building from source
- Remove `--timeout=10m` (deprecated in v2; timeout is disabled by default)

### .golangci.yml
- Add required `version: "2"` declaration
- Move `gofmt` and `goimports` from linters to new `formatters` section (no longer linters in v2)
- Replace `stylecheck` with `staticcheck` (merged in v2)
- Nest `linters-settings` under `linters.settings`

### Lint fixes
- **errcheck**: Wrap deferred `Close()` and `RemoveAll()` calls to handle return values
- **staticcheck**: Convert if/else protocol checks to switch statements in `ToNFTables()`

## Test plan
- [x] `make lint` passes clean (0 issues)
- [x] `make test` passes (all unit tests green)
- [ ] CI checks pass

Jira: [CNF-23208](https://redhat.atlassian.net/browse/CNF-23208)