### PR TITLE
CNF-23209: Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to automate dependency update PRs
- Configures weekly updates for both GitHub Actions and Go module dependencies

## Ecosystems
- **github-actions**: Weekly updates for any workflow action versions
- **gomod**: Weekly updates for Go module dependencies (go.mod/go.sum)

## Test plan
- [ ] CI checks pass
- [ ] Dependabot starts opening PRs on the configured schedule

Jira: [CNF-23209](https://redhat.atlassian.net/browse/CNF-23209)