### PR TITLE
CNF-23307: Standardize error wrapping with %w across the codebase

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -135,7 +135,7 @@ func NewCmdCommatrixGenerate(cs *client.ClientSet, streams genericiooptions.IOSt
 			}
 
 			if err := Run(o); err != nil {
-				return fmt.Errorf("failed to generate matrix: %v", err)
+				return fmt.Errorf("failed to generate matrix: %w", err)
 			}
 			return nil
 		},
@@ -237,7 +237,7 @@ func Complete(o *GenerateOptions) error {
 		o.destDir = consts.CommatrixDefaultDir
 		log.Debugf("Creating communication-matrix default path: %s", o.destDir)
 		if err := os.MkdirAll(o.destDir, 0755); err != nil {
-			return fmt.Errorf("failed to create destination directory '%s': %v", o.destDir, err)
+			return fmt.Errorf("failed to create destination directory '%s': %w", o.destDir, err)
 		}
 	}
 
@@ -252,12 +252,12 @@ func Run(o *GenerateOptions) (err error) {
 	log.Debug("Detecting deployment and infra types")
 	controlPlaneTopology, err := o.utilsHelpers.GetControlPlaneTopology()
 	if err != nil {
-		return fmt.Errorf("failed to get control plane topology %s", err)
+		return fmt.Errorf("failed to get control plane topology: %w", err)
 	}
 
 	platformType, err := o.utilsHelpers.GetPlatformType()
 	if err != nil {
-		return fmt.Errorf("failed to get platform type %s", err)
+		return fmt.Errorf("failed to get platform type: %w", err)
 	}
 
 	if !slices.Contains(types.SupportedPlatforms, platformType) {
@@ -271,7 +271,7 @@ func Run(o *GenerateOptions) (err error) {
 
 	ipv6Enabled, err := o.utilsHelpers.IsIPv6Enabled()
 	if err != nil {
-		return fmt.Errorf("failed to detect IPv6: %v", err)
+		return fmt.Errorf("failed to detect IPv6: %w", err)
 	}
 
 	// DHCP is only supported on BareMetal and None platforms
@@ -279,7 +279,7 @@ func Run(o *GenerateOptions) (err error) {
 	if platformType == configv1.BareMetalPlatformType || platformType == configv1.NonePlatformType {
 		dhcpEnabled, err = o.utilsHelpers.IsDHCPEnabled()
 		if err != nil {
-			return fmt.Errorf("failed to detect DHCP: %v", err)
+			return fmt.Errorf("failed to detect DHCP: %w", err)
 		}
 		if dhcpEnabled {
 			log.Debug("DHCP enabled")
@@ -392,7 +392,7 @@ func generateMatrix(o *GenerateOptions, controlPlaneTopology configv1.TopologyMo
 
 	epExporter, err := endpointslices.New(o.cs, o.customNodeGroups)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating the endpointslices exporter %s", err)
+		return nil, fmt.Errorf("failed creating the endpointslices exporter: %w", err)
 	}
 
 	log.Debug("Creating communication matrix")
@@ -433,13 +433,13 @@ func generateSS(o *GenerateOptions) (*listeningsockets.SSResult, error) {
 	log.Debug("Creating listening socket check")
 	listeningCheck, err := listeningsockets.NewCheck(o.cs, o.utilsHelpers, o.customNodeGroups)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating listening socket check: %v", err)
+		return nil, fmt.Errorf("failed creating listening socket check: %w", err)
 	}
 
 	log.Debug("Creating namespace")
 	err = o.utilsHelpers.CreateNamespace(consts.DefaultDebugNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create namespace: %v", err)
+		return nil, fmt.Errorf("failed to create namespace: %w", err)
 	}
 	// Always delete namespace and wait for full removal to avoid Terminating races on reruns
 	defer func() {
@@ -451,7 +451,7 @@ func generateSS(o *GenerateOptions) (*listeningsockets.SSResult, error) {
 	log.Debug("Generating SS matrix and raw files")
 	result, err := listeningCheck.GenerateSS(consts.DefaultDebugNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("error while generating the listening check matrix and ss raws: %v", err)
+		return nil, fmt.Errorf("error while generating the listening check matrix and ss raws: %w", err)
 	}
 	return result, nil
 }

--- a/pkg/commatrix-creator/commatrix.go
+++ b/pkg/commatrix-creator/commatrix.go
@@ -103,7 +103,7 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 	staticEntries, err := cm.getStaticEntries()
 	if err != nil {
 		log.Errorf("Failed adding static entries: %s", err)
-		return nil, fmt.Errorf("failed adding static entries: %s", err)
+		return nil, fmt.Errorf("failed adding static entries: %w", err)
 	}
 
 	// List of [master, worker] roles per pool for static entries expansion
@@ -129,7 +129,7 @@ func (cm *CommunicationMatrixCreator) CreateEndpointMatrix() (*types.ComMatrix, 
 		customMatrix, err := cm.GetComMatrixFromFile()
 		if err != nil {
 			log.Errorf("Failed adding custom entries: %s", err)
-			return nil, fmt.Errorf("failed adding custom entries: %s", err)
+			return nil, fmt.Errorf("failed adding custom entries: %w", err)
 		}
 		epSliceComDetails = append(epSliceComDetails, customMatrix.Ports...)
 		dynamicRanges = append(dynamicRanges, customMatrix.DynamicRanges...)
@@ -146,7 +146,7 @@ func (cm *CommunicationMatrixCreator) GetComMatrixFromFile() (*types.ComMatrix, 
 	f, err := os.Open(filepath.Clean(cm.customEntriesPath))
 	if err != nil {
 		log.Errorf("Failed to open file %s: %v", cm.customEntriesPath, err)
-		return nil, fmt.Errorf("failed to open file %s: %v", cm.customEntriesPath, err)
+		return nil, fmt.Errorf("failed to open file %s: %w", cm.customEntriesPath, err)
 	}
 	defer f.Close()
 
@@ -154,14 +154,14 @@ func (cm *CommunicationMatrixCreator) GetComMatrixFromFile() (*types.ComMatrix, 
 	raw, err := io.ReadAll(f)
 	if err != nil {
 		log.Errorf("Failed to read file %s: %v", cm.customEntriesPath, err)
-		return nil, fmt.Errorf("failed to read file %s: %v", cm.customEntriesPath, err)
+		return nil, fmt.Errorf("failed to read file %s: %w", cm.customEntriesPath, err)
 	}
 
 	log.Debugf("Unmarshalling file content with format %s", cm.customEntriesFormat)
 	res, err := types.ParseToComMatrix(raw, cm.customEntriesFormat)
 	if err != nil {
 		log.Errorf("Failed to unmarshal %s file: %v", cm.customEntriesFormat, err)
-		return nil, fmt.Errorf("failed to unmarshal custom entries file: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal custom entries file: %w", err)
 	}
 
 	log.Debug("Successfully unmarshalled custom entries")

--- a/pkg/endpointslices/endpointslices.go
+++ b/pkg/endpointslices/endpointslices.go
@@ -85,11 +85,11 @@ func (ep *EndpointSlicesExporter) LoadExposedEndpointSlicesInfo() error {
 		epl := &discoveryv1.EndpointSliceList{}
 		label, err := labels.Parse(fmt.Sprintf("kubernetes.io/service-name=%s", service.Name))
 		if err != nil {
-			return fmt.Errorf("failed to create selector for endpoint slice, %v", err)
+			return fmt.Errorf("failed to create selector for endpoint slice: %w", err)
 		}
 		err = ep.List(context.TODO(), epl, &rtclient.ListOptions{Namespace: service.Namespace, LabelSelector: label})
 		if err != nil {
-			return fmt.Errorf("failed to list endpoint slice, %v", err)
+			return fmt.Errorf("failed to list endpoint slice: %w", err)
 		}
 
 		if len(epl.Items) == 0 {
@@ -106,7 +106,7 @@ func (ep *EndpointSlicesExporter) LoadExposedEndpointSlicesInfo() error {
 		label = labels.SelectorFromSet(service.Spec.Selector)
 		err = ep.List(context.TODO(), pods, &rtclient.ListOptions{Namespace: service.Namespace, LabelSelector: label})
 		if err != nil {
-			return fmt.Errorf("failed to list pods, %v", err)
+			return fmt.Errorf("failed to list pods: %w", err)
 		}
 
 		// If there are no pods found for the service, skip.

--- a/pkg/firewall/machineconfig.go
+++ b/pkg/firewall/machineconfig.go
@@ -35,7 +35,7 @@ func NFTablesToMachineConfig(nftRules []byte, nodePool string, utilsHelpers util
 
 	machineConfig, _, err := butaneConfig.TranslateBytes(butaneCfg, common.TranslateBytesOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert Butane config to MachineConfig YAML: %v", err)
+		return nil, fmt.Errorf("failed to convert Butane config to MachineConfig YAML: %w", err)
 	}
 
 	return machineConfig, nil
@@ -50,7 +50,7 @@ func NFTablesToMachineConfig(nftRules []byte, nodePool string, utilsHelpers util
 func buildButaneConfig(nftablesRules, nodePool string, utilsHelpers utils.UtilsInterface) ([]byte, error) {
 	clusterVersion, err := utilsHelpers.GetClusterVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster version for Butane spec: %v", err)
+		return nil, fmt.Errorf("failed to get cluster version for Butane spec: %w", err)
 	}
 	butaneVersion, err := resolveButaneVersion(clusterVersion)
 	if err != nil {
@@ -110,7 +110,7 @@ storage:
 func resolveButaneVersion(clusterVersion string) (string, error) {
 	cv, err := semver.NewVersion(clusterVersion)
 	if err != nil {
-		return "", fmt.Errorf("invalid cluster version %q: %v", clusterVersion, err)
+		return "", fmt.Errorf("invalid cluster version %q: %w", clusterVersion, err)
 	}
 	max, _ := semver.NewVersion(maxButaneVersion)
 	if cv.GreaterThan(max) {

--- a/pkg/matrix-diff/matrix-diff.go
+++ b/pkg/matrix-diff/matrix-diff.go
@@ -55,7 +55,7 @@ func Generate(primary *types.ComMatrix, secondary *types.ComMatrix) MatrixDiff {
 func (m *MatrixDiff) String() (string, error) {
 	colNames, err := types.GetComMatrixHeadersByFormat(types.FormatCSV)
 	if err != nil {
-		return "", fmt.Errorf("error getting commatrix CSV tags: %v", err)
+		return "", fmt.Errorf("error getting commatrix CSV tags: %w", err)
 	}
 	diff := colNames + "\n"
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -314,7 +314,7 @@ func (m *ComMatrix) writeMatrixToFile(utilsHelpers utils.UtilsInterface, fileNam
 func writeNodeDisruptionPolicyFile(utilsHelpers utils.UtilsInterface, destDir string) error {
 	patchPath := filepath.Join(destDir, consts.NodeDisruptionPolicyFileName)
 	if err := utilsHelpers.WriteFile(patchPath, []byte(firewall.NodeDisruptionPolicyPatch)); err != nil {
-		return fmt.Errorf("failed to write NodeDisruptionPolicy patch file: %v", err)
+		return fmt.Errorf("failed to write NodeDisruptionPolicy patch file: %w", err)
 	}
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -98,7 +98,7 @@ func (u *utils) resolveImageStreamTag(namespace, name, tag string) (string, erro
 	}
 	var image string
 	if image, _, _, _, err = imageutil.ResolveRecentPullSpecForTag(imageStream, tag, false); err != nil {
-		return "", fmt.Errorf("unable to resolve the imagestream tag %s/%s:%s: %v", namespace, name, tag, err)
+		return "", fmt.Errorf("unable to resolve the imagestream tag %s/%s:%s: %w", namespace, name, tag, err)
 	}
 	return image, nil
 }
@@ -107,13 +107,13 @@ func (u *utils) CreateNamespace(namespace string) error {
 	ns := getNamespaceDefinition(namespace)
 	err := u.Create(context.TODO(), ns)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed creating namespace %s: %v", namespace, err)
+		return fmt.Errorf("failed creating namespace %s: %w", namespace, err)
 	}
 
 	// wait for it to be ready with the openshift.io/sa.scc.uid-range Annotation
 	err = u.waitForNamespaceSCCUAnnotation(ns)
 	if err != nil {
-		return fmt.Errorf("failed to wait for annotation 'openshift.io/sa.scc.uid-range' in namespace %s: %v", namespace, err)
+		return fmt.Errorf("failed to wait for annotation 'openshift.io/sa.scc.uid-range' in namespace %s: %w", namespace, err)
 	}
 
 	return nil
@@ -134,7 +134,7 @@ func (u *utils) DeleteNamespace(namespace string) error {
 	ns := getNamespaceDefinition(namespace)
 	err := u.Delete(context.TODO(), ns)
 	if err != nil {
-		return fmt.Errorf("failed deleting namespace %s: %v", namespace, err)
+		return fmt.Errorf("failed deleting namespace %s: %w", namespace, err)
 	}
 	if pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		ns := &corev1.Namespace{}
@@ -143,7 +143,7 @@ func (u *utils) DeleteNamespace(namespace string) error {
 			return true, nil
 		}
 		if err != nil {
-			return false, fmt.Errorf("retrying due to error: %v", err) // keep retrying
+			return false, fmt.Errorf("retrying due to error: %w", err) // keep retrying
 		}
 		return false, nil
 	}); pollErr != nil {

--- a/test/pkg/cluster/cluster.go
+++ b/test/pkg/cluster/cluster.go
@@ -88,7 +88,7 @@ func AddNFTSvcToNodeDisruptionPolicy(cs *client.ClientSet) error {
 	_, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Apply(context.TODO(), applyConfiguration,
 		metav1.ApplyOptions{FieldManager: "machine-config-operator", Force: true})
 	if err != nil {
-		return fmt.Errorf("updating cluster node disruption policy failed %v", err)
+		return fmt.Errorf("updating cluster node disruption policy failed: %w", err)
 	}
 
 	log.Println("MachineConfiguration updated successfully!")

--- a/test/pkg/firewall/firewall.go
+++ b/test/pkg/firewall/firewall.go
@@ -12,7 +12,7 @@ func CreateMachineConfig(NFTtable []byte, artifactsDir, nodePool string,
 	utilsHelpers utils.UtilsInterface) (machineConfig []byte, err error) {
 	machineConfig, err = firewall.NFTablesToMachineConfig(NFTtable, nodePool, utilsHelpers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert nftables to MachineConfig: %v", err)
+		return nil, fmt.Errorf("failed to convert nftables to MachineConfig: %w", err)
 	}
 
 	fileName := fmt.Sprintf("mc-%s.yaml", nodePool)


### PR DESCRIPTION
## Summary
- Replace `%s` and `%v` with `%w` in all `fmt.Errorf` calls to enable proper error chain unwrapping via `errors.Is()` and `errors.As()`
- 30 lines across 9 files — each change is a single-character format verb substitution with no behavioral changes
- `log.Errorf` calls (logrus) are left as-is since logrus does not support `%w`

## Files changed
- `cmd/generate/generate.go` (10)
- `pkg/commatrix-creator/commatrix.go` (5)
- `pkg/utils/utils.go` (5)
- `pkg/firewall/machineconfig.go` (3)
- `pkg/endpointslices/endpointslices.go` (3)
- `pkg/types/types.go` (1)
- `pkg/matrix-diff/matrix-diff.go` (1)
- `test/pkg/firewall/firewall.go` (1)
- `test/pkg/cluster/cluster.go` (1)

## Related to

- [redhat-best-practices-for-k8s/certsuite#3730](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3730) — `%w` error wrapping in certsuite (open)
- [openshift/tls-scanner#70](https://github.com/openshift/tls-scanner/pull/70) — `%w` error wrapping in tls-scanner (merged)
- [crc-org/crc#5180](https://github.com/crc-org/crc/pull/5180) — `%w` error wrapping in crc (merged)
- [openshift-kni/lifecycle-agent#6319](https://github.com/openshift-kni/lifecycle-agent/pull/6319) — bare error wrapping in lifecycle-agent (open)
- [redhat-best-practices-for-k8s/certsuite#3633](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3633) — bare error wrapping in certsuite (merged)
- [redhat-best-practices-for-k8s/certsuite#3627](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3627) — bare error wrapping in certsuite (merged)

## Test plan
- [x] `make lint` passes clean
- [x] `make test` passes (all unit tests green)
- [x] CI checks pass

Jira: [CNF-23307](https://redhat.atlassian.net/browse/CNF-23307)