### PR TITLE
CNF-23438: Log warnings when loopback IP detection fails

### DIFF
--- a/pkg/listening-sockets/listening-sockets.go
+++ b/pkg/listening-sockets/listening-sockets.go
@@ -340,10 +340,12 @@ func (cc *ConnectionCheck) getLoopbackIPs(debugPod *corev1.Pod) map[string]bool 
 	}
 	out, err := cc.podUtils.RunCommandOnPod(debugPod, []string{"chroot", "/host", "/bin/sh", "-c", "ip -j addr show lo"})
 	if err != nil {
+		log.Warningf("failed to get loopback IPs from pod %s: %v", debugPod.Name, err)
 		return map[string]bool{}
 	}
 	var parsed []iface
-	if json.Unmarshal(out, &parsed) != nil {
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		log.Warningf("failed to parse loopback IP output from pod %s: %v", debugPod.Name, err)
 		return map[string]bool{}
 	}
 	ips := make(map[string]bool)


### PR DESCRIPTION
## Summary
- Add `log.Warningf` calls in `getLoopbackIPs()` so failures from `RunCommandOnPod` and `json.Unmarshal` are visible in logs
- Previously, both errors were silently discarded, returning an empty map with no indication of failure
- Without loopback IP detection, localhost-bound ports incorrectly appear in the communication matrix

## Test plan
- [x] `go test ./pkg/listening-sockets/... -v` — 7/7 pass
- [x] `make lint` — clean

Jira: [CNF-23438](https://redhat.atlassian.net/browse/CNF-23438)