### PR TITLE
CNF-23444: Add etcd port 2381 to documented communication matrices

### DIFF
--- a/docs/stable/raw/aws-sno.csv
+++ b/docs/stable/raw/aws-sno.csv
@@ -5,6 +5,7 @@ Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
+Ingress,TCP,2381,openshift-etcd,etcd,etcd,etcd,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
 Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE

--- a/docs/stable/raw/aws.csv
+++ b/docs/stable/raw/aws.csv
@@ -3,6 +3,7 @@ Ingress,TCP,22,Host system service,sshd,,,master,TRUE
 Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
+Ingress,TCP,2381,openshift-etcd,etcd,etcd,etcd,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
 Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE

--- a/docs/stable/raw/bm.csv
+++ b/docs/stable/raw/bm.csv
@@ -4,6 +4,7 @@ Ingress,TCP,53,openshift-dns,dns-default,dns-default,dns,master,FALSE
 Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
+Ingress,TCP,2381,openshift-etcd,etcd,etcd,etcd,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
 Ingress,TCP,6180,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6183,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE

--- a/docs/stable/raw/none-sno.csv
+++ b/docs/stable/raw/none-sno.csv
@@ -7,6 +7,7 @@ Ingress,TCP,443,openshift-ingress,router-internal-default,router-default,router,
 Ingress,TCP,1936,openshift-ingress,router-internal-default,router-default,router,master,FALSE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
+Ingress,TCP,2381,openshift-etcd,etcd,etcd,etcd,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
 Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE


### PR DESCRIPTION
## Summary
- Add etcd port 2381 (health/metrics endpoint via `listen-metrics-urls`) to all four documented CSV files
- This port is present on clusters but was missing from the docs, causing e2e validation test failures across all open PRs

## Files changed
- `docs/stable/raw/aws.csv`
- `docs/stable/raw/aws-sno.csv`
- `docs/stable/raw/bm.csv`
- `docs/stable/raw/none-sno.csv`

## Test plan
- [x] `go build ./...` — clean
- [x] `make lint` — clean
- [ ] e2e validation test should pass once this is merged (currently failing on all open PRs with the same error)

Jira: [CNF-23444](https://redhat.atlassian.net/browse/CNF-23444)