### PR TITLE
Fix nil pointer dereference in toComDetails when port parsing fails

### DIFF
--- a/pkg/listening-sockets/listening-sockets.go
+++ b/pkg/listening-sockets/listening-sockets.go
@@ -149,6 +149,9 @@ func (cc *ConnectionCheck) toComDetails(debugPod *corev1.Pod, ssOutput []string,
 
 	for _, ssEntry := range ssOutput {
 		cd := parseComDetail(ssEntry)
+		if cd == nil {
+			continue
+		}
 
 		containerName, nameSpace, podName := "", "", ""
 		containerInfo, err := cc.getContainerInfo(debugPod, ssEntry)


### PR DESCRIPTION
## Summary

- `parseComDetail()` returns `nil` when `strconv.Atoi` fails on the port string, but `toComDetails()` dereferences the result at `*cd` without a nil check, causing a panic
- Added a nil guard to skip unparseable ss entries — the debug log inside `parseComDetail` already records the failure

## Test plan

- [ ] Existing e2e tests pass (commatrix-e2e-tests-1of2, 2of2)
- [ ] Unit tests pass
- [ ] Lint passes